### PR TITLE
Delete Node class and fully deprecate nodes as a distinct concept

### DIFF
--- a/src/gems/study/__init__.py
+++ b/src/gems/study/__init__.py
@@ -21,4 +21,4 @@ from .data import (
     TimeScenarioSeriesData,
     TimeSeriesData,
 )
-from .network import Component, Node, PortRef, PortsConnection, System, create_component
+from .network import Component, PortRef, PortsConnection, System, create_component

--- a/src/gems/study/network.py
+++ b/src/gems/study/network.py
@@ -15,9 +15,8 @@ The system module defines the data model for an instance of a system,
 including components and connections.
 """
 
-import itertools
 from dataclasses import dataclass, field, replace
-from typing import Any, Dict, Iterable, List, cast
+from typing import Any, Dict, Iterable, List
 
 from gems.model import PortField, PortType
 from gems.model.model import Model
@@ -43,19 +42,6 @@ class Component:
 
 def create_component(model: Model, id: str) -> Component:
     return Component(model=model, id=id)
-
-
-@dataclass(frozen=True)
-class Node(Component):
-    """
-    A node in the system.
-    """
-
-    pass
-
-
-def create_node(model: Model, id: str) -> Node:
-    return Node(model=model, id=id)
 
 
 @dataclass(frozen=True)
@@ -127,13 +113,8 @@ class System:
     """
 
     id: str
-    _nodes: Dict[str, Node] = field(init=False, default_factory=dict)
     _components: Dict[str, Component] = field(init=False, default_factory=dict)
     _connections: List[PortsConnection] = field(init=False, default_factory=list)
-
-    def _check_node_exists(self, node_id: str) -> None:
-        if node_id not in self._nodes:
-            raise ValueError(f"Node {node_id} does not exist in the system.")
 
     def _check_model_id_unique(self, model: Model) -> None:
         for existing in self.all_components:
@@ -148,33 +129,15 @@ class System:
         self._components[component.id] = component
 
     def get_component(self, component_id: str) -> Component:
-        """
-        Returns the component (possibly a node) corresponding to this ID.
-        """
-        res = self._components.get(component_id, None)
-        return res if res else self._nodes[component_id]
+        return self._components[component_id]
 
     @property
     def components(self) -> Iterable[Component]:
         return self._components.values()
 
-    def add_node(self, node: Node) -> None:
-        self._check_model_id_unique(node.model)
-        self._nodes[node.id] = node
-
-    def get_node(self, node_id: str) -> Node:
-        return self._nodes[node_id]
-
-    @property
-    def nodes(self) -> Iterable[Node]:
-        return self._nodes.values()
-
     @property
     def all_components(self) -> Iterable[Component]:
-        """
-        An iterable over both nodes and components.
-        """
-        return itertools.chain(self.nodes, self.components)
+        return self._components.values()
 
     def connect(self, port1: PortRef, port2: PortRef) -> None:
         ports_connection = PortsConnection(port1, port2)
@@ -188,13 +151,10 @@ class System:
         return self._connections[idx]
 
     def is_empty(self) -> bool:
-        return (not self._nodes) and (not self._components) and (not self._connections)
+        return (not self._components) and (not self._connections)
 
     def replicate(self, /, **changes: Any) -> "System":
         replica: System = replace(self, **changes)
-
-        for node in self.nodes:
-            replica.add_node(cast(Node, node.replicate()))
 
         for component in self.components:
             replica.add_component(component.replicate())

--- a/src/gems/study/parsing.py
+++ b/src/gems/study/parsing.py
@@ -76,7 +76,6 @@ class InputSystem(ModifiedBaseModel):
     components: List[InputComponent] = Field(default_factory=list)
     connections: Optional[List[InputPortConnections]] = None
     area_connections: Optional[List[InputAreaConnections]] = None
-    nodes: Optional[List[InputComponent]] = []
 
 
 @dataclass(frozen=True)

--- a/src/gems/study/resolve_components.py
+++ b/src/gems/study/resolve_components.py
@@ -20,7 +20,6 @@ from gems.study import (
     Component,
     ConstantData,
     DataBase,
-    Node,
     PortRef,
     PortsConnection,
     Scenarization,
@@ -46,19 +45,14 @@ def resolve_system(input_system: InputSystem, libraries: dict[str, Library]) -> 
     components_list = [
         _resolve_component(libraries, m) for m in input_system.components
     ]
-    nodes_input = getattr(input_system, "nodes", []) or []
-    nodes = [_resolve_component(libraries, n) for n in nodes_input]
 
     s = System("study")
-    for n in nodes:
-        s.add_node(Node(model=n.model, id=n.id))
     for component in components_list:
         s.add_component(component)
 
-    all_components: List[Component] = components_list + nodes
     connections_input = getattr(input_system, "connections", []) or []
     for cnx in connections_input:
-        port_ref_1, port_ref_2 = _resolve_port_refs(cnx, all_components)
+        port_ref_1, port_ref_2 = _resolve_port_refs(cnx, components_list)
         s.connect(port_ref_1, port_ref_2)
 
     return s
@@ -114,9 +108,7 @@ def build_data_base(
     input_system: InputSystem, timeseries_dir: Optional[Path]
 ) -> DataBase:
     database = DataBase()
-    nodes_input = getattr(input_system, "nodes", []) or []
-    input_system_objects = input_system.components + nodes_input
-    for comp in input_system_objects:
+    for comp in input_system.components:
         # This idiom allows mypy to 'ignore' the fact that comp.parameter can be None
         for param in comp.parameters or []:
             param_value = _build_data(

--- a/tests/e2e/functional/systems/components_for_short_term_storage.yml
+++ b/tests/e2e/functional/systems/components_for_short_term_storage.yml
@@ -11,11 +11,9 @@
 # This file is part of the Antares project.
 system:
   model-libraries: basic
-  nodes:
+  components:
     - id: N
       model: basic.node
-
-  components:
     - id: D
       model: basic.demand
       parameters:

--- a/tests/e2e/functional/systems/study_scenario_only_series.yml
+++ b/tests/e2e/functional/systems/study_scenario_only_series.yml
@@ -11,11 +11,9 @@
 # This file is part of the Antares project.
 system:
   model-libraries: basic
-  nodes:
+  components:
     - id: N
       model: basic.node
-
-  components:
     - id: G
       model: basic.generator
       parameters:

--- a/tests/e2e/functional/systems/study_time_only_series.yml
+++ b/tests/e2e/functional/systems/study_time_only_series.yml
@@ -11,11 +11,9 @@
 # This file is part of the Antares project.
 system:
   model-libraries: basic
-  nodes:
+  components:
     - id: N
       model: basic.node
-
-  components:
     - id: G
       model: basic.generator
       parameters:

--- a/tests/e2e/functional/systems/system.yml
+++ b/tests/e2e/functional/systems/system.yml
@@ -11,11 +11,9 @@
 # This file is part of the Antares project.
 system:
   model-libraries: basic
-  nodes:
+  components:
     - id: N
       model: basic.node
-
-  components:
     - id: G
       model: basic.generator
       parameters:

--- a/tests/e2e/functional/systems/system_time_shift_per_component.yml
+++ b/tests/e2e/functional/systems/system_time_shift_per_component.yml
@@ -33,11 +33,9 @@
 system:
   model-libraries: time_shift_test
 
-  nodes:
+  components:
     - id: N
       model: time_shift_test.node
-
-  components:
     - id: D
       model: time_shift_test.demand
       parameters:

--- a/tests/e2e/functional/systems/system_with_varying_down_time.yml
+++ b/tests/e2e/functional/systems/system_with_varying_down_time.yml
@@ -37,11 +37,9 @@
 #   Total                         = 12250
 system:
   model-libraries: basic
-  nodes:
+  components:
     - id: N
       model: basic.node
-
-  components:
     - id: G_0
       model: basic.thermal-cluster-dhd
       parameters:

--- a/tests/e2e/functional/systems/with_scenarization.yml
+++ b/tests/e2e/functional/systems/with_scenarization.yml
@@ -11,11 +11,9 @@
 # This file is part of the Antares project.
 system:
   model-libraries: basic
-  nodes:
+  components:
     - id: N
       model: basic.node
-
-  components:
     - id: G
       model: basic.generator
       parameters:

--- a/tests/e2e/functional/test_component_dependent_time_shift.py
+++ b/tests/e2e/functional/test_component_dependent_time_shift.py
@@ -89,9 +89,9 @@ from gems.model.port import PortFieldDefinition, PortFieldId
 from gems.model.resolve_library import resolve_library
 from gems.simulation import BlockBorderManagement, TimeBlock, build_problem
 from gems.study import (
+    Component,
     ConstantData,
     DataBase,
-    Node,
     PortRef,
     System,
     TimeScenarioSeriesData,
@@ -193,7 +193,7 @@ def _add_storage(
 
 
 def _build_system(*storage_ids: str) -> System:
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     demand_comp = create_component(model=DEMAND_MODEL, id="D")
     spillage_comp = create_component(model=SPILLAGE_MODEL, id="S")
     unsupplied_comp = create_component(model=UNSUPPLIED_ENERGY_MODEL, id="U")
@@ -202,7 +202,7 @@ def _build_system(*storage_ids: str) -> System:
     ]
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     for comp in [demand_comp, spillage_comp, unsupplied_comp] + storage_comps:
         system.add_component(comp)
         system.connect(PortRef(comp, "balance_port"), PortRef(node, "balance_port"))

--- a/tests/e2e/functional/test_investment.py
+++ b/tests/e2e/functional/test_investment.py
@@ -36,7 +36,6 @@ from gems.study import (
     Component,
     ConstantData,
     DataBase,
-    Node,
     PortRef,
     System,
     TimeScenarioSeriesData,
@@ -205,9 +204,9 @@ def test_generation_xpansion_single_time_step_single_scenario(
     database.add_data("CAND", "invest_cost", ConstantData(490))
     database.add_data("CAND", "max_invest", ConstantData(1000))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(generator)
     system.add_component(candidate)
@@ -279,9 +278,9 @@ def test_two_candidates_xpansion_single_time_step_single_scenario(
     database.add_data("DISCRETE", "invest_cost", ConstantData(200))
     database.add_data("DISCRETE", "p_max_per_unit", ConstantData(10))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(generator)
     system.add_component(candidate)
@@ -369,9 +368,9 @@ def test_generation_xpansion_two_time_steps_two_scenarios(
     database.add_data("CAND", "invest_cost", ConstantData(490))
     database.add_data("CAND", "max_invest", ConstantData(1000))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(generator)
     system.add_component(candidate)

--- a/tests/e2e/functional/test_libs_python_system_python.py
+++ b/tests/e2e/functional/test_libs_python_system_python.py
@@ -43,9 +43,9 @@ from gems.model import Model, ModelPort, float_parameter, float_variable, model
 from gems.model.port import PortFieldDefinition, PortFieldId
 from gems.simulation import BlockBorderManagement, TimeBlock, build_problem
 from gems.study import (
+    Component,
     ConstantData,
     DataBase,
-    Node,
     PortRef,
     System,
     TimeScenarioIndex,
@@ -74,7 +74,7 @@ def test_basic_balance() -> None:
     database.add_data("G", "p_max", ConstantData(100))
     database.add_data("G", "cost", ConstantData(30))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     demand = create_component(
         model=DEMAND_MODEL,
         id="D",
@@ -86,7 +86,7 @@ def test_basic_balance() -> None:
     )
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))
@@ -120,7 +120,7 @@ def test_timeseries() -> None:
     demand_time_scenario_series = TimeScenarioSeriesData(demand_data)
     database.add_data("D", "demand", demand_time_scenario_series)
 
-    node = Node(model=NODE_BALANCE_MODEL, id="1")
+    node = Component(model=NODE_BALANCE_MODEL, id="1")
     demand = create_component(
         model=DEMAND_MODEL,
         id="D",
@@ -132,7 +132,7 @@ def test_timeseries() -> None:
     )
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))
@@ -148,7 +148,7 @@ def test_timeseries() -> None:
 
 
 def create_one_node_network(generator_model: Model) -> System:
-    node = Node(model=NODE_BALANCE_MODEL, id="1")
+    node = Component(model=NODE_BALANCE_MODEL, id="1")
     demand = create_component(
         model=DEMAND_MODEL,
         id="D",
@@ -160,7 +160,7 @@ def create_one_node_network(generator_model: Model) -> System:
     )
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))
@@ -272,7 +272,7 @@ def short_term_storage_base(efficiency: float, horizon: int) -> None:
     database.add_data("STS1", "inflows", ConstantData(0))
     database.add_data("STS1", "efficiency", ConstantData(efficiency))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="1")
+    node = Component(model=NODE_BALANCE_MODEL, id="1")
     spillage = create_component(model=SPILLAGE_MODEL, id="S")
 
     unsupplied = create_component(model=UNSUPPLIED_ENERGY_MODEL, id="U")
@@ -285,7 +285,7 @@ def short_term_storage_base(efficiency: float, horizon: int) -> None:
     )
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     for component in [demand, short_term_storage, spillage, unsupplied]:
         system.add_component(component)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))

--- a/tests/e2e/functional/test_libs_yaml_system_python.py
+++ b/tests/e2e/functional/test_libs_yaml_system_python.py
@@ -36,9 +36,9 @@ import pytest
 from gems.model.library import Library
 from gems.simulation import BlockBorderManagement, TimeBlock, build_problem
 from gems.study import (
+    Component,
     ConstantData,
     DataBase,
-    Node,
     PortRef,
     System,
     TimeScenarioSeriesData,
@@ -63,7 +63,7 @@ def test_basic_balance(lib_dict: dict[str, Library]) -> None:
     demand_model = lib_dict["basic"].models["basic.demand"]
     production_model = lib_dict["basic"].models["basic.production"]
 
-    node = Node(model=node_model, id="N")
+    node = Component(model=node_model, id="N")
     demand = create_component(
         model=demand_model,
         id="D",
@@ -75,7 +75,7 @@ def test_basic_balance(lib_dict: dict[str, Library]) -> None:
     )
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))
@@ -106,8 +106,8 @@ def test_link(lib_dict: dict[str, Library]) -> None:
     production_model = lib_dict["basic"].models["basic.production"]
     link_model = lib_dict["basic"].models["basic.link"]
 
-    node1 = Node(model=node_model, id="1")
-    node2 = Node(model=node_model, id="2")
+    node1 = Component(model=node_model, id="1")
+    node2 = Component(model=node_model, id="2")
     demand = create_component(
         model=demand_model,
         id="D",
@@ -122,8 +122,8 @@ def test_link(lib_dict: dict[str, Library]) -> None:
     )
 
     system = System("test")
-    system.add_node(node1)
-    system.add_node(node2)
+    system.add_component(node1)
+    system.add_component(node2)
     system.add_component(demand)
     system.add_component(gen)
     system.add_component(link)
@@ -159,7 +159,7 @@ def test_stacking_generation(lib_dict: dict[str, Library]) -> None:
     demand_model = lib_dict["basic"].models["basic.demand"]
     production_model = lib_dict["basic"].models["basic.production"]
 
-    node1 = Node(model=node_model, id="1")
+    node1 = Component(model=node_model, id="1")
 
     demand = create_component(
         model=demand_model,
@@ -177,7 +177,7 @@ def test_stacking_generation(lib_dict: dict[str, Library]) -> None:
     )
 
     system = System("test")
-    system.add_node(node1)
+    system.add_component(node1)
     system.add_component(demand)
     system.add_component(gen1)
     system.add_component(gen2)
@@ -210,14 +210,14 @@ def test_spillage(lib_dict: dict[str, Library]) -> None:
     production_with_min_model = lib_dict["basic"].models["basic.production_with_min"]
     spillage_model = lib_dict["basic"].models["basic.spillage"]
 
-    node = Node(model=node_model, id="1")
+    node = Component(model=node_model, id="1")
     spillage = create_component(model=spillage_model, id="S")
     demand = create_component(model=demand_model, id="D")
 
     gen1 = create_component(model=production_with_min_model, id="G1")
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen1)
     system.add_component(spillage)
@@ -288,7 +288,7 @@ def test_min_up_down_times(lib_dict: dict[str, Library]) -> None:
     unsuplied_model = lib_dict["basic"].models["basic.unsuplied"]
     thermal_cluster = lib_dict["basic"].models["basic.thermal_cluster"]
 
-    node = Node(model=node_model, id="1")
+    node = Component(model=node_model, id="1")
     demand = create_component(model=demand_model, id="D")
 
     gen = create_component(model=thermal_cluster, id="G")
@@ -298,7 +298,7 @@ def test_min_up_down_times(lib_dict: dict[str, Library]) -> None:
     unsupplied_energy = create_component(model=unsuplied_model, id="U")
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.add_component(spillage)
@@ -354,13 +354,13 @@ def test_changing_demand(lib_dict: dict[str, Library]) -> None:
     demand_model = lib_dict["basic"].models["basic.demand"]
     production_model = lib_dict["basic"].models["basic.production"]
 
-    node = Node(model=node_model, id="1")
+    node = Component(model=node_model, id="1")
     demand = create_component(model=demand_model, id="D")
 
     prod = create_component(model=production_model, id="G")
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(prod)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))
@@ -435,7 +435,7 @@ def test_min_up_down_times_2(lib_dict: dict[str, Library]) -> None:
     unsuplied_model = lib_dict["basic"].models["basic.unsuplied"]
     thermal_cluster = lib_dict["basic"].models["basic.thermal_cluster"]
 
-    node = Node(model=node_model, id="1")
+    node = Component(model=node_model, id="1")
     demand = create_component(model=demand_model, id="D")
 
     gen = create_component(model=thermal_cluster, id="G")
@@ -445,7 +445,7 @@ def test_min_up_down_times_2(lib_dict: dict[str, Library]) -> None:
     unsupplied_energy = create_component(model=unsuplied_model, id="U")
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.add_component(spillage)

--- a/tests/e2e/functional/test_performance.py
+++ b/tests/e2e/functional/test_performance.py
@@ -20,7 +20,7 @@ from gems.expression.expression import ExpressionNode, literal, param, var
 from gems.expression.indexing_structure import IndexingStructure
 from gems.model import float_parameter, float_variable, model
 from gems.simulation import TimeBlock, build_problem
-from gems.study import ConstantData, DataBase, Node, PortRef, System, create_component
+from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
 from gems.study.data import TimeScenarioSeriesData
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,
@@ -174,7 +174,7 @@ def test_large_sum_of_port_connections() -> None:
         database.add_data(f"G_{gen_id}", "p_max", ConstantData(1))
         database.add_data(f"G_{gen_id}", "cost", ConstantData(5))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     demand = create_component(model=DEMAND_MODEL, id="D")
     generators = [
         create_component(model=GENERATOR_MODEL, id=f"G_{gen_id}")
@@ -182,7 +182,7 @@ def test_large_sum_of_port_connections() -> None:
     ]
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
 
     system.add_component(demand)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))
@@ -216,13 +216,13 @@ def test_basic_balance_on_whole_year() -> None:
     database.add_data("G", "p_max", ConstantData(100))
     database.add_data("G", "cost", ConstantData(30))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     demand = create_component(model=DEMAND_MODEL, id="D")
 
     gen = create_component(model=GENERATOR_MODEL, id="G")
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))
@@ -254,14 +254,14 @@ def test_basic_balance_on_whole_year_with_large_sum() -> None:
     database.add_data("G", "cost", ConstantData(30))
     database.add_data("G", "full_storage", ConstantData(100 * horizon))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     demand = create_component(model=DEMAND_MODEL, id="D")
     gen = create_component(
         model=GENERATOR_MODEL_WITH_STORAGE, id="G"
     )  # Limits the total generation inside a TimeBlock
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))

--- a/tests/e2e/functional/test_performance.py
+++ b/tests/e2e/functional/test_performance.py
@@ -20,7 +20,14 @@ from gems.expression.expression import ExpressionNode, literal, param, var
 from gems.expression.indexing_structure import IndexingStructure
 from gems.model import float_parameter, float_variable, model
 from gems.simulation import TimeBlock, build_problem
-from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
+from gems.study import (
+    Component,
+    ConstantData,
+    DataBase,
+    PortRef,
+    System,
+    create_component,
+)
 from gems.study.data import TimeScenarioSeriesData
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,

--- a/tests/e2e/functional/test_scalability.py
+++ b/tests/e2e/functional/test_scalability.py
@@ -5,9 +5,9 @@ import pandas as pd
 
 from gems.simulation import TimeBlock, build_problem
 from gems.study import (
+    Component,
     ConstantData,
     DataBase,
-    Node,
     PortRef,
     System,
     TimeScenarioSeriesData,
@@ -55,14 +55,14 @@ def build_for_horizon(horizon_size: int, scenario_count: int) -> float:
     database.add_data("G", "cost", ConstantData(30))
     database.add_data("G", "full_storage", ConstantData(100 * horizon_size))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     demand = create_component(model=DEMAND_MODEL, id="D")
     gen = create_component(
         model=GENERATOR_MODEL_WITH_STORAGE, id="G"
     )  # Limits the total generation inside a TimeBlock
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))

--- a/tests/e2e/functional/test_stochastic.py
+++ b/tests/e2e/functional/test_stochastic.py
@@ -16,7 +16,14 @@ import pandas as pd
 import pytest
 
 from gems.simulation import TimeBlock, build_problem
-from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
+from gems.study import (
+    Component,
+    ConstantData,
+    DataBase,
+    PortRef,
+    System,
+    create_component,
+)
 from gems.study.data import TimeScenarioSeriesData
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,

--- a/tests/e2e/functional/test_stochastic.py
+++ b/tests/e2e/functional/test_stochastic.py
@@ -16,7 +16,7 @@ import pandas as pd
 import pytest
 
 from gems.simulation import TimeBlock, build_problem
-from gems.study import ConstantData, DataBase, Node, PortRef, System, create_component
+from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
 from gems.study.data import TimeScenarioSeriesData
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,
@@ -104,7 +104,7 @@ def test_stochastic_model_with_HD_for_thermal_startup(
     Randomness only comes from the availability of thermal plants, demand is fixed.
     """
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     demand = create_component(model=DEMAND_MODEL, id="D")
 
     base = create_component(model=THERMAL_CLUSTER_MODEL_HD, id="BASE")
@@ -114,7 +114,7 @@ def test_stochastic_model_with_HD_for_thermal_startup(
     peak = create_component(model=THERMAL_CLUSTER_MODEL_HD, id="PEAK")
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(base)
     system.add_component(semibase)
@@ -160,7 +160,7 @@ def test_stochastic_model_with_DH_for_thermal_startup(
 
     time_blocks = [TimeBlock(1, list(range(horizon)))]
 
-    node = Node(model=NODE_BALANCE_MODEL, id="N")
+    node = Component(model=NODE_BALANCE_MODEL, id="N")
     demand = create_component(model=DEMAND_MODEL, id="D")
 
     base = create_component(model=THERMAL_CLUSTER_MODEL_DHD, id="BASE")
@@ -170,7 +170,7 @@ def test_stochastic_model_with_DH_for_thermal_startup(
     peak = create_component(model=THERMAL_CLUSTER_MODEL_DHD, id="PEAK")
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(base)
     system.add_component(semibase)

--- a/tests/e2e/models/operators/optest1/input/system.yml
+++ b/tests/e2e/models/operators/optest1/input/system.yml
@@ -165,4 +165,3 @@ system: #This system aims at testing the correct handling of complex expressions
     port1: balance_port
     port2: balance_port
   id: e2e_general_test_177428933315
-  nodes: []

--- a/tests/e2e/models/operators/optest2/input/system.yml
+++ b/tests/e2e/models/operators/optest2/input/system.yml
@@ -166,4 +166,3 @@ system: #This system aims at testing the correct handling of complex expressions
     port1: balance_port
     port2: balance_port
   id: e2e_general_test_177428933315
-  nodes: []

--- a/tests/e2e/models/operators/optest3/input/system.yml
+++ b/tests/e2e/models/operators/optest3/input/system.yml
@@ -165,4 +165,3 @@ system: #This system aims at testing the correct handling of complex expressions
     port1: balance_port
     port2: balance_port
   id: e2e_general_test_177428933315
-  nodes: []

--- a/tests/e2e/models/operators/optest4/input/system.yml
+++ b/tests/e2e/models/operators/optest4/input/system.yml
@@ -165,4 +165,3 @@ system: #This system aims at testing the correct handling of complex expressions
     port1: balance_port
     port2: balance_port
   id: e2e_general_test_177428933315
-  nodes: []

--- a/tests/e2e/models/poc-various-models/test_ac_link.py
+++ b/tests/e2e/models/poc-various-models/test_ac_link.py
@@ -19,7 +19,14 @@ from gems.model.parsing import parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
+from gems.study import (
+    Component,
+    ConstantData,
+    DataBase,
+    PortRef,
+    System,
+    create_component,
+)
 
 
 @pytest.fixture

--- a/tests/e2e/models/poc-various-models/test_ac_link.py
+++ b/tests/e2e/models/poc-various-models/test_ac_link.py
@@ -19,7 +19,7 @@ from gems.model.parsing import parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import ConstantData, DataBase, Node, PortRef, System, create_component
+from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def test_ac_network_no_links(ac_lib: dict[str, Library]) -> None:
     database.add_data("G", "p_max", ConstantData(100))
     database.add_data("G", "cost", ConstantData(30))
 
-    node = Node(model=ac_node_model, id="N")
+    node = Component(model=ac_node_model, id="N")
     demand = create_component(
         model=DEMAND_MODEL,
         id="D",
@@ -67,7 +67,7 @@ def test_ac_network_no_links(ac_lib: dict[str, Library]) -> None:
     )
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "injections"))
@@ -101,8 +101,8 @@ def test_ac_network(ac_lib: dict[str, Library]) -> None:
 
     database.add_data("L", "reactance", ConstantData(1))
 
-    node1 = Node(model=ac_node_model, id="1")
-    node2 = Node(model=ac_node_model, id="2")
+    node1 = Component(model=ac_node_model, id="1")
+    node2 = Component(model=ac_node_model, id="2")
     demand = create_component(
         model=DEMAND_MODEL,
         id="D",
@@ -119,8 +119,8 @@ def test_ac_network(ac_lib: dict[str, Library]) -> None:
     )
 
     system = System("test")
-    system.add_node(node1)
-    system.add_node(node2)
+    system.add_component(node1)
+    system.add_component(node2)
     system.add_component(demand)
     system.add_component(gen)
     system.add_component(link)
@@ -165,8 +165,8 @@ def test_parallel_ac_links(ac_lib: dict[str, Library]) -> None:
     database.add_data("L1", "reactance", ConstantData(1))
     database.add_data("L2", "reactance", ConstantData(2))
 
-    node1 = Node(model=ac_node_model, id="1")
-    node2 = Node(model=ac_node_model, id="2")
+    node1 = Component(model=ac_node_model, id="1")
+    node2 = Component(model=ac_node_model, id="2")
     demand = create_component(
         model=DEMAND_MODEL,
         id="D",
@@ -185,8 +185,8 @@ def test_parallel_ac_links(ac_lib: dict[str, Library]) -> None:
     )
 
     system = System("test")
-    system.add_node(node1)
-    system.add_node(node2)
+    system.add_component(node1)
+    system.add_component(node2)
     system.add_component(demand)
     system.add_component(gen)
     system.add_component(link1)
@@ -242,8 +242,8 @@ def test_parallel_ac_links_with_pst(ac_lib: dict[str, Library]) -> None:
     database.add_data("T", "flow_limit", ConstantData(50))
     database.add_data("T", "phase_shift_cost", ConstantData(1))
 
-    node1 = Node(model=ac_node_model, id="1")
-    node2 = Node(model=ac_node_model, id="2")
+    node1 = Component(model=ac_node_model, id="1")
+    node2 = Component(model=ac_node_model, id="2")
     demand = create_component(
         model=DEMAND_MODEL,
         id="D",
@@ -262,8 +262,8 @@ def test_parallel_ac_links_with_pst(ac_lib: dict[str, Library]) -> None:
     )
 
     system = System("test")
-    system.add_node(node1)
-    system.add_node(node2)
+    system.add_component(node1)
+    system.add_component(node2)
     system.add_component(demand)
     system.add_component(gen)
     system.add_component(link1)

--- a/tests/e2e/models/poc-various-models/test_electrolyzer.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer.py
@@ -25,7 +25,14 @@ from gems.model import (
 )
 from gems.model.port import PortFieldDefinition, PortFieldId
 from gems.simulation import TimeBlock, build_problem
-from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
+from gems.study import (
+    Component,
+    ConstantData,
+    DataBase,
+    PortRef,
+    System,
+    create_component,
+)
 
 ELECTRICAL_PORT = PortType(id="electrical_port", fields=[PortField("flow")])
 

--- a/tests/e2e/models/poc-various-models/test_electrolyzer.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer.py
@@ -25,7 +25,7 @@ from gems.model import (
 )
 from gems.model.port import PortFieldDefinition, PortFieldId
 from gems.simulation import TimeBlock, build_problem
-from gems.study import ConstantData, DataBase, Node, PortRef, System, create_component
+from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
 
 ELECTRICAL_PORT = PortType(id="electrical_port", fields=[PortField("flow")])
 
@@ -123,8 +123,8 @@ ELECTROLYZER = model(
 
 
 def test_electrolyzer() -> None:
-    elec_node = Node(model=ELECTRICAL_NODE_MODEL, id="1")
-    h2_node = Node(model=H2_NODE_MODEL, id="2")
+    elec_node = Component(model=ELECTRICAL_NODE_MODEL, id="1")
+    h2_node = Component(model=H2_NODE_MODEL, id="2")
 
     electric_gen = create_component(
         model=ELECTRICAL_GENERATOR_MODEL,
@@ -149,8 +149,8 @@ def test_electrolyzer() -> None:
     database.add_data("E", "efficiency", ConstantData(0.7))
 
     system = System("test")
-    system.add_node(elec_node)
-    system.add_node(h2_node)
+    system.add_component(elec_node)
+    system.add_component(h2_node)
     system.add_component(demand_h2)
     system.add_component(electric_gen)
     system.add_component(electrolyzer)

--- a/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs.py
@@ -23,7 +23,14 @@ from libs.standard_sc import (
 
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
+from gems.study import (
+    Component,
+    ConstantData,
+    DataBase,
+    PortRef,
+    System,
+    create_component,
+)
 
 """
 This file tests various modellings for an electrolyser with multiple inputs. The models are created in Python directly.

--- a/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs.py
@@ -23,7 +23,7 @@ from libs.standard_sc import (
 
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import ConstantData, DataBase, Node, PortRef, System, create_component
+from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
 
 """
 This file tests various modellings for an electrolyser with multiple inputs. The models are created in Python directly.
@@ -60,15 +60,15 @@ def test_electrolyzer_n_inputs_1() -> None:
     total gaz production = flow_ep1 * alpha_ez1 + flow_ep2 * alpha_ez2 + flow_gp
 
     """
-    elec_node_1 = Node(model=NODE_BALANCE_MODEL, id="e1")
+    elec_node_1 = Component(model=NODE_BALANCE_MODEL, id="e1")
     electric_prod_1 = create_component(model=GENERATOR_MODEL, id="ep1")
     electrolyzer1 = create_component(model=CONVERTOR_MODEL, id="ez1")
 
-    elec_node_2 = Node(model=NODE_BALANCE_MODEL, id="e2")
+    elec_node_2 = Component(model=NODE_BALANCE_MODEL, id="e2")
     electric_prod_2 = create_component(model=GENERATOR_MODEL, id="ep2")
     electrolyzer2 = create_component(model=CONVERTOR_MODEL, id="ez2")
 
-    gaz_node = Node(model=NODE_BALANCE_MODEL, id="g")
+    gaz_node = Component(model=NODE_BALANCE_MODEL, id="g")
     gaz_prod = create_component(model=GENERATOR_MODEL, id="gp")
     gaz_demand = create_component(model=DEMAND_MODEL, id="gd")
 
@@ -87,13 +87,13 @@ def test_electrolyzer_n_inputs_1() -> None:
     database.add_data("gp", "cost", ConstantData(15))
 
     system = System("test")
-    system.add_node(elec_node_1)
+    system.add_component(elec_node_1)
     system.add_component(electric_prod_1)
     system.add_component(electrolyzer1)
-    system.add_node(elec_node_2)
+    system.add_component(elec_node_2)
     system.add_component(electric_prod_2)
     system.add_component(electrolyzer2)
-    system.add_node(gaz_node)
+    system.add_component(gaz_node)
     system.add_component(gaz_prod)
     system.add_component(gaz_demand)
 
@@ -154,9 +154,9 @@ def test_electrolyzer_n_inputs_2() -> None:
     total gaz production = flow_ep1 * alpha1_ez + flow_ep2 * alpha2_ez + flow_gp
     """
 
-    elec_node_1 = Node(model=NODE_BALANCE_MODEL, id="e1")
-    elec_node_2 = Node(model=NODE_BALANCE_MODEL, id="e2")
-    gaz_node = Node(model=NODE_BALANCE_MODEL, id="g")
+    elec_node_1 = Component(model=NODE_BALANCE_MODEL, id="e1")
+    elec_node_2 = Component(model=NODE_BALANCE_MODEL, id="e2")
+    gaz_node = Component(model=NODE_BALANCE_MODEL, id="g")
 
     electric_prod_1 = create_component(model=GENERATOR_MODEL, id="ep1")
     electric_prod_2 = create_component(model=GENERATOR_MODEL, id="ep2")
@@ -182,9 +182,9 @@ def test_electrolyzer_n_inputs_2() -> None:
     database.add_data("gp", "cost", ConstantData(15))
 
     system = System("test")
-    system.add_node(elec_node_1)
-    system.add_node(elec_node_2)
-    system.add_node(gaz_node)
+    system.add_component(elec_node_1)
+    system.add_component(elec_node_2)
+    system.add_component(gaz_node)
     system.add_component(electric_prod_1)
     system.add_component(electric_prod_2)
     system.add_component(gaz_prod)
@@ -248,9 +248,9 @@ def test_electrolyzer_n_inputs_3() -> None:
 
     The result is different since we only have one alpha at 0.7
     """
-    elec_node_1 = Node(model=NODE_BALANCE_MODEL, id="e1")
-    elec_node_2 = Node(model=NODE_BALANCE_MODEL, id="e2")
-    gaz_node = Node(model=NODE_BALANCE_MODEL, id="g")
+    elec_node_1 = Component(model=NODE_BALANCE_MODEL, id="e1")
+    elec_node_2 = Component(model=NODE_BALANCE_MODEL, id="e2")
+    gaz_node = Component(model=NODE_BALANCE_MODEL, id="g")
 
     electric_prod_1 = create_component(model=GENERATOR_MODEL, id="ep1")
     electric_prod_2 = create_component(model=GENERATOR_MODEL, id="ep2")
@@ -278,9 +278,9 @@ def test_electrolyzer_n_inputs_3() -> None:
     database.add_data("gp", "cost", ConstantData(15))
 
     system = System("test")
-    system.add_node(elec_node_1)
-    system.add_node(elec_node_2)
-    system.add_node(gaz_node)
+    system.add_component(elec_node_1)
+    system.add_component(elec_node_2)
+    system.add_component(gaz_node)
     system.add_component(electric_prod_1)
     system.add_component(electric_prod_2)
     system.add_component(gaz_prod)
@@ -350,9 +350,9 @@ def test_electrolyzer_n_inputs_4() -> None:
 
     same as test 3, the result is different than the first two since we only have one alpha at 0.7
     """
-    elec_node_1 = Node(model=NODE_BALANCE_MODEL_MOD, id="e1")
-    elec_node_2 = Node(model=NODE_BALANCE_MODEL_MOD, id="e2")
-    gaz_node = Node(model=NODE_BALANCE_MODEL, id="g")
+    elec_node_1 = Component(model=NODE_BALANCE_MODEL_MOD, id="e1")
+    elec_node_2 = Component(model=NODE_BALANCE_MODEL_MOD, id="e2")
+    gaz_node = Component(model=NODE_BALANCE_MODEL, id="g")
 
     electric_prod_1 = create_component(model=GENERATOR_MODEL, id="ep1")
     electric_prod_2 = create_component(model=GENERATOR_MODEL, id="ep2")
@@ -377,9 +377,9 @@ def test_electrolyzer_n_inputs_4() -> None:
     database.add_data("gp", "cost", ConstantData(15))
 
     system = System("test")
-    system.add_node(elec_node_1)
-    system.add_node(elec_node_2)
-    system.add_node(gaz_node)
+    system.add_component(elec_node_1)
+    system.add_component(elec_node_2)
+    system.add_component(gaz_node)
     system.add_component(electric_prod_1)
     system.add_component(electric_prod_2)
     system.add_component(gaz_prod)

--- a/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs_yaml.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs_yaml.py
@@ -15,7 +15,14 @@ import math
 from gems.model.library import Library
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
+from gems.study import (
+    Component,
+    ConstantData,
+    DataBase,
+    PortRef,
+    System,
+    create_component,
+)
 
 """
 This file tests various modellings for an electrolyser with multiple inputs. The models are read from a YAML model file.

--- a/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs_yaml.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs_yaml.py
@@ -15,7 +15,7 @@ import math
 from gems.model.library import Library
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import ConstantData, DataBase, Node, PortRef, System, create_component
+from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
 
 """
 This file tests various modellings for an electrolyser with multiple inputs. The models are read from a YAML model file.
@@ -60,15 +60,15 @@ def test_electrolyzer_n_inputs_1(
     convertor_model = lib_dict_sc["basic"].models["basic.convertor"]
     demand_model = lib_dict["basic"].models["basic.demand"]
 
-    elec_node_1 = Node(model=node_model, id="e1")
+    elec_node_1 = Component(model=node_model, id="e1")
     electric_prod_1 = create_component(model=gen_model, id="ep1")
     electrolyzer1 = create_component(model=convertor_model, id="ez1")
 
-    elec_node_2 = Node(model=node_model, id="e2")
+    elec_node_2 = Component(model=node_model, id="e2")
     electric_prod_2 = create_component(model=gen_model, id="ep2")
     electrolyzer2 = create_component(model=convertor_model, id="ez2")
 
-    gaz_node = Node(model=node_model, id="g")
+    gaz_node = Component(model=node_model, id="g")
     gaz_prod = create_component(model=gen_model, id="gp")
     gaz_demand = create_component(model=demand_model, id="gd")
 
@@ -87,13 +87,13 @@ def test_electrolyzer_n_inputs_1(
     database.add_data("gp", "cost", ConstantData(15))
 
     system = System("test")
-    system.add_node(elec_node_1)
+    system.add_component(elec_node_1)
     system.add_component(electric_prod_1)
     system.add_component(electrolyzer1)
-    system.add_node(elec_node_2)
+    system.add_component(elec_node_2)
     system.add_component(electric_prod_2)
     system.add_component(electrolyzer2)
-    system.add_node(gaz_node)
+    system.add_component(gaz_node)
     system.add_component(gaz_prod)
     system.add_component(gaz_demand)
 
@@ -169,9 +169,9 @@ def test_electrolyzer_n_inputs_2(
     convertor_model = lib_dict_sc["basic"].models["basic.two_input_convertor"]
     demand_model = lib_dict["basic"].models["basic.demand"]
 
-    elec_node_1 = Node(model=node_model, id="e1")
-    elec_node_2 = Node(model=node_model, id="e2")
-    gaz_node = Node(model=node_model, id="g")
+    elec_node_1 = Component(model=node_model, id="e1")
+    elec_node_2 = Component(model=node_model, id="e2")
+    gaz_node = Component(model=node_model, id="g")
 
     electric_prod_1 = create_component(model=gen_model, id="ep1")
     electric_prod_2 = create_component(model=gen_model, id="ep2")
@@ -197,9 +197,9 @@ def test_electrolyzer_n_inputs_2(
     database.add_data("gp", "cost", ConstantData(15))
 
     system = System("test")
-    system.add_node(elec_node_1)
-    system.add_node(elec_node_2)
-    system.add_node(gaz_node)
+    system.add_component(elec_node_1)
+    system.add_component(elec_node_2)
+    system.add_component(gaz_node)
     system.add_component(electric_prod_1)
     system.add_component(electric_prod_2)
     system.add_component(gaz_prod)
@@ -280,9 +280,9 @@ def test_electrolyzer_n_inputs_3(
         "basic.decompose_1_flow_into_2_flow"
     ]
 
-    elec_node_1 = Node(model=node_model, id="e1")
-    elec_node_2 = Node(model=node_model, id="e2")
-    gaz_node = Node(model=node_model, id="g")
+    elec_node_1 = Component(model=node_model, id="e1")
+    elec_node_2 = Component(model=node_model, id="e2")
+    gaz_node = Component(model=node_model, id="g")
 
     electric_prod_1 = create_component(model=gen_model, id="ep1")
     electric_prod_2 = create_component(model=gen_model, id="ep2")
@@ -308,9 +308,9 @@ def test_electrolyzer_n_inputs_3(
     database.add_data("gp", "cost", ConstantData(15))
 
     system = System("test")
-    system.add_node(elec_node_1)
-    system.add_node(elec_node_2)
-    system.add_node(gaz_node)
+    system.add_component(elec_node_1)
+    system.add_component(elec_node_2)
+    system.add_component(gaz_node)
     system.add_component(electric_prod_1)
     system.add_component(electric_prod_2)
     system.add_component(gaz_prod)
@@ -396,9 +396,9 @@ def test_electrolyzer_n_inputs_4(
     convertor_model = lib_dict_sc["basic"].models["basic.convertor_receive_in"]
     demand_model = lib_dict["basic"].models["basic.demand"]
 
-    elec_node_1 = Node(model=node_mod_model, id="e1")
-    elec_node_2 = Node(model=node_mod_model, id="e2")
-    gaz_node = Node(model=node_model, id="g")
+    elec_node_1 = Component(model=node_mod_model, id="e1")
+    elec_node_2 = Component(model=node_mod_model, id="e2")
+    gaz_node = Component(model=node_model, id="g")
 
     electric_prod_1 = create_component(model=gen_model, id="ep1")
     electric_prod_2 = create_component(model=gen_model, id="ep2")
@@ -423,9 +423,9 @@ def test_electrolyzer_n_inputs_4(
     database.add_data("gp", "cost", ConstantData(15))
 
     system = System("test")
-    system.add_node(elec_node_1)
-    system.add_node(elec_node_2)
-    system.add_node(gaz_node)
+    system.add_component(elec_node_1)
+    system.add_component(elec_node_2)
+    system.add_component(gaz_node)
     system.add_component(electric_prod_1)
     system.add_component(electric_prod_2)
     system.add_component(gaz_prod)

--- a/tests/e2e/models/poc-various-models/test_quota_co2.py
+++ b/tests/e2e/models/poc-various-models/test_quota_co2.py
@@ -21,7 +21,7 @@ from libs.standard_sc import C02_POWER_MODEL, QUOTA_CO2_MODEL
 
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import ConstantData, DataBase, Node, PortRef, System, create_component
+from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
 
 
 def test_quota_co2() -> None:
@@ -37,8 +37,8 @@ def test_quota_co2() -> None:
     QuotaCO2
 
     Test of a generation of energy and co2 with a quota to limit the emission"""
-    n1 = Node(model=NODE_BALANCE_MODEL, id="N1")
-    n2 = Node(model=NODE_BALANCE_MODEL, id="N2")
+    n1 = Component(model=NODE_BALANCE_MODEL, id="N1")
+    n2 = Component(model=NODE_BALANCE_MODEL, id="N2")
     oil1 = create_component(model=C02_POWER_MODEL, id="Oil1")
     coal1 = create_component(model=C02_POWER_MODEL, id="Coal1")
     l12 = create_component(model=LINK_MODEL, id="L12")
@@ -46,8 +46,8 @@ def test_quota_co2() -> None:
     monQuotaCO2 = create_component(model=QUOTA_CO2_MODEL, id="QuotaCO2")
 
     system = System("test")
-    system.add_node(n1)
-    system.add_node(n2)
+    system.add_component(n1)
+    system.add_component(n2)
     system.add_component(oil1)
     system.add_component(coal1)
     system.add_component(l12)

--- a/tests/e2e/models/poc-various-models/test_quota_co2.py
+++ b/tests/e2e/models/poc-various-models/test_quota_co2.py
@@ -21,7 +21,14 @@ from libs.standard_sc import C02_POWER_MODEL, QUOTA_CO2_MODEL
 
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
+from gems.study import (
+    Component,
+    ConstantData,
+    DataBase,
+    PortRef,
+    System,
+    create_component,
+)
 
 
 def test_quota_co2() -> None:

--- a/tests/e2e/models/poc-various-models/test_quota_co2_yaml.py
+++ b/tests/e2e/models/poc-various-models/test_quota_co2_yaml.py
@@ -19,7 +19,14 @@ import math
 from gems.model.library import Library
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
+from gems.study import (
+    Component,
+    ConstantData,
+    DataBase,
+    PortRef,
+    System,
+    create_component,
+)
 
 
 def test_quota_co2(

--- a/tests/e2e/models/poc-various-models/test_quota_co2_yaml.py
+++ b/tests/e2e/models/poc-various-models/test_quota_co2_yaml.py
@@ -19,7 +19,7 @@ import math
 from gems.model.library import Library
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
-from gems.study import ConstantData, DataBase, Node, PortRef, System, create_component
+from gems.study import Component, ConstantData, DataBase, PortRef, System, create_component
 
 
 def test_quota_co2(
@@ -43,8 +43,8 @@ def test_quota_co2(
     demand_model = lib_dict["basic"].models["basic.demand"]
     link_model = lib_dict_sc["basic"].models["basic.link"]
 
-    n1 = Node(model=node_model, id="N1")
-    n2 = Node(model=node_model, id="N2")
+    n1 = Component(model=node_model, id="N1")
+    n2 = Component(model=node_model, id="N2")
     oil1 = create_component(model=gen_model, id="Oil1")
     coal1 = create_component(model=gen_model, id="Coal1")
     l12 = create_component(model=link_model, id="L12")
@@ -52,8 +52,8 @@ def test_quota_co2(
     monQuotaCO2 = create_component(model=quota_co2_model, id="QuotaCO2")
 
     system = System("test")
-    system.add_node(n1)
-    system.add_node(n2)
+    system.add_component(n1)
+    system.add_component(n2)
     system.add_component(oil1)
     system.add_component(coal1)
     system.add_component(l12)

--- a/tests/e2e/models/poc-various-models/test_short_term_storage_complex.py
+++ b/tests/e2e/models/poc-various-models/test_short_term_storage_complex.py
@@ -11,9 +11,9 @@ from libs.standard_sc import SHORT_TERM_STORAGE_COMPLEX
 
 from gems.simulation import BlockBorderManagement, TimeBlock, build_problem
 from gems.study import (
+    Component,
     ConstantData,
     DataBase,
-    Node,
     PortRef,
     System,
     TimeScenarioSeriesData,
@@ -66,7 +66,7 @@ def short_term_storage_base(efficiency: float, horizon: int, result: int) -> Non
     database.add_data("STS1", "Pgrad+s_penality", ConstantData(0))
     database.add_data("STS1", "Pgrad-s_penality", ConstantData(0))
 
-    node = Node(model=NODE_BALANCE_MODEL, id="1")
+    node = Component(model=NODE_BALANCE_MODEL, id="1")
     spillage = create_component(model=SPILLAGE_MODEL, id="S")
 
     unsupplied = create_component(model=UNSUPPLIED_ENERGY_MODEL, id="U")
@@ -79,7 +79,7 @@ def short_term_storage_base(efficiency: float, horizon: int, result: int) -> Non
     )
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     for component in [demand, short_term_storage, spillage, unsupplied]:
         system.add_component(component)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))

--- a/tests/unittests/scenario_builder/systems/with_scenarization.yml
+++ b/tests/unittests/scenario_builder/systems/with_scenarization.yml
@@ -11,11 +11,9 @@
 # This file is part of the Antares project.
 system:
   model-libraries: basic
-  nodes:
+  components:
     - id: N
       model: basic.node
-
-  components:
     - id: G
       model: basic.generator
       parameters:

--- a/tests/unittests/simulation/test_simulation_table_extra_outputs.py
+++ b/tests/unittests/simulation/test_simulation_table_extra_outputs.py
@@ -22,7 +22,7 @@ def test_extra_output_with_sum_connections() -> None:
     from gems.model.port import PortField, PortFieldDefinition, PortFieldId, PortType
     from gems.model.variable import float_variable
     from gems.simulation import TimeBlock, build_problem
-    from gems.study import DataBase, Node, PortRef, System, create_component
+    from gems.study import Component, DataBase, PortRef, System, create_component
 
     BALANCE_PORT_TYPE = PortType(id="balance", fields=[PortField("flow")])
 
@@ -53,11 +53,11 @@ def test_extra_output_with_sum_connections() -> None:
     database = DataBase()
 
     gen_comp = create_component(model=GEN_MODEL, id="gen_1")
-    node_comp = Node(model=NODE_MODEL, id="node_1")
+    node_comp = Component(model=NODE_MODEL, id="node_1")
 
     system = System("test_sum_connections")
     system.add_component(gen_comp)
-    system.add_node(node_comp)
+    system.add_component(node_comp)
     system.connect(
         PortRef(gen_comp, "balance_port"), PortRef(node_comp, "balance_port")
     )

--- a/tests/unittests/system/test_data_consistency.py
+++ b/tests/unittests/system/test_data_consistency.py
@@ -27,9 +27,9 @@ from gems.model import (
 )
 from gems.model.port import PortFieldDefinition, PortFieldId
 from gems.study import (
+    Component,
     ConstantData,
     DataBase,
-    Node,
     PortRef,
     ScenarioIndex,
     ScenarioSeriesData,
@@ -52,13 +52,13 @@ from tests.unittests.system.libs.standard import (
 
 @pytest.fixture
 def mock_network() -> System:
-    node = Node(model=NODE_BALANCE_MODEL, id="1")
+    node = Component(model=NODE_BALANCE_MODEL, id="1")
     demand = create_component(model=DEMAND_MODEL, id="D")
 
     gen = create_component(model=GENERATOR_MODEL, id="G")
 
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(demand)
     system.add_component(gen)
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))
@@ -208,7 +208,7 @@ def test_requirements_consistency_time_varying_parameter_with_correct_data_passe
     # Given
     # Model for test with parameter NON_ANTICIPATIVE_TIME_VARYING
 
-    node = Node(model=NODE_BALANCE_MODEL, id="1")
+    node = Component(model=NODE_BALANCE_MODEL, id="1")
     gen = create_component(
         model=mock_generator_with_fixed_scenario_time_varying_param, id="G"
     )
@@ -219,7 +219,7 @@ def test_requirements_consistency_time_varying_parameter_with_correct_data_passe
     database.add_data("G", "p_max", ConstantData(100))
     database.add_data("G", "cost", cost_data)
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(gen)
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "balance_port"))
 
@@ -252,7 +252,7 @@ def test_requirements_consistency_time_varying_parameter_with_scenario_varying_d
     # Given
     # Model for test with parameter NON_ANTICIPATIVE_TIME_VARYING
 
-    node = Node(model=NODE_BALANCE_MODEL, id="1")
+    node = Component(model=NODE_BALANCE_MODEL, id="1")
     gen = create_component(
         model=mock_generator_with_fixed_scenario_time_varying_param,
         id="G",
@@ -262,7 +262,7 @@ def test_requirements_consistency_time_varying_parameter_with_scenario_varying_d
     database.add_data("G", "p_max", ConstantData(100))
     database.add_data("G", "cost", cost_data)
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(gen)
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "balance_port"))
 
@@ -290,7 +290,7 @@ def test_requirements_consistency_scenario_varying_parameter_with_time_varying_d
     # Given
     # Model for test with parameter indexed by scenario only
 
-    node = Node(model=NODE_BALANCE_MODEL, id="1")
+    node = Component(model=NODE_BALANCE_MODEL, id="1")
     gen = create_component(
         model=mock_generator_with_scenario_varying_fixed_time_param, id="G"
     )
@@ -299,7 +299,7 @@ def test_requirements_consistency_scenario_varying_parameter_with_time_varying_d
     database.add_data("G", "p_max", ConstantData(100))
     database.add_data("G", "cost", cost_data)
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(gen)
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "balance_port"))
 
@@ -314,7 +314,7 @@ def test_requirements_consistency_scenario_varying_parameter_with_correct_data_p
     # Given
     # Model for test with parameter indexed by scenario only
 
-    node = Node(model=NODE_BALANCE_MODEL, id="1")
+    node = Component(model=NODE_BALANCE_MODEL, id="1")
     gen = create_component(
         model=mock_generator_with_scenario_varying_fixed_time_param, id="G"
     )
@@ -325,7 +325,7 @@ def test_requirements_consistency_scenario_varying_parameter_with_correct_data_p
     database.add_data("G", "p_max", ConstantData(100))
     database.add_data("G", "cost", cost_data)
     system = System("test")
-    system.add_node(node)
+    system.add_component(node)
     system.add_component(gen)
     system.add_component(gen)
 

--- a/tests/unittests/system/test_port.py
+++ b/tests/unittests/system/test_port.py
@@ -15,7 +15,7 @@ import pytest
 from gems.expression import literal
 from gems.expression.expression import port_field
 from gems.model import Constraint, ModelPort, PortType, model
-from gems.study import Node, PortRef, PortsConnection, create_component
+from gems.study import Component, PortRef, PortsConnection, create_component
 from tests.unittests.system.libs.standard import DEMAND_MODEL
 
 
@@ -32,7 +32,7 @@ def test_port_type_compatibility_ko() -> None:
             )
         ],
     )
-    node = Node(id="N", model=NODE_BALANCE_MODEL_FAKE)
+    node = Component(id="N", model=NODE_BALANCE_MODEL_FAKE)
     demand = create_component(
         model=DEMAND_MODEL,
         id="D",

--- a/tests/unittests/system/test_system.py
+++ b/tests/unittests/system/test_system.py
@@ -17,7 +17,7 @@ import pytest
 from gems.model.library import Library
 from gems.model.parsing import parse_yaml_library
 from gems.model.resolve_library import resolve_library
-from gems.study.network import Node, System
+from gems.study.network import Component, System
 
 
 @pytest.fixture(scope="session")
@@ -40,22 +40,18 @@ def test_system(lib_dict: dict[str, Library]) -> None:
     # This test could be done without parsing the yaml lib, ie. by giving models directly as Python object
     system = System("test")
     assert system.id == "test"
-    assert list(system.nodes) == []
     assert list(system.components) == []
     assert list(system.all_components) == []
     assert list(system.connections) == []
 
-    with pytest.raises(KeyError):
-        system.get_node("N")
-
     node_model = lib_dict["basic"].models["basic.node"]
 
-    N1 = Node(model=node_model, id="N1")
-    N2 = Node(model=node_model, id="N2")
-    system.add_node(N1)
-    system.add_node(N2)
-    assert list(system.nodes) == [N1, N2]
-    assert system.get_node(N1.id) == N1
-    assert system.get_component("N1") == Node(model=node_model, id="N1")
+    N1 = Component(model=node_model, id="N1")
+    N2 = Component(model=node_model, id="N2")
+    system.add_component(N1)
+    system.add_component(N2)
+    assert list(system.components) == [N1, N2]
+    assert system.get_component(N1.id) == N1
+    assert system.get_component("N1") == Component(model=node_model, id="N1")
     with pytest.raises(KeyError):
         system.get_component("unknown")

--- a/tests/unittests/system_parsing/systems/system.yml
+++ b/tests/unittests/system_parsing/systems/system.yml
@@ -11,11 +11,9 @@
 # This file is part of the Antares project.
 system:
   model-libraries: basic
-  nodes:
+  components:
     - id: N
       model: basic.node
-
-  components:
     - id: G
       model: basic.generator
       parameters:

--- a/tests/unittests/system_parsing/test_components_parsing.py
+++ b/tests/unittests/system_parsing/test_components_parsing.py
@@ -28,16 +28,13 @@ def input_library() -> InputLibrary:
 def test_parsing_components_ok(
     input_system: InputSystem, input_library: InputLibrary
 ) -> None:
-    assert len(input_system.components) == 2
-    assert input_system.nodes is not None
-    assert len(input_system.nodes) == 1
+    assert len(input_system.components) == 3
     assert input_system.connections is not None
     assert len(input_system.connections) == 2
     lib_dict = resolve_library([input_library])
     result = resolve_system(input_system, lib_dict)
 
-    assert len(result.components) == 2
-    assert len(result.nodes) == 1
+    assert len(result.components) == 3
     assert len(result.connections) == 2
 
 
@@ -58,9 +55,10 @@ def test_load_input_system_ok(tmp_path: Path) -> None:
     result = load_input_system(file_for_load)
 
     assert isinstance(result, InputSystem)
-    assert len(result.components) == 2
-    assert result.components[0].id == "G"
-    assert result.components[1].id == "D"
+    assert len(result.components) == 3
+    assert result.components[0].id == "N"
+    assert result.components[1].id == "G"
+    assert result.components[2].id == "D"
     assert result.connections is not None
     assert len(result.connections) == 2
 


### PR DESCRIPTION
Node was an empty frozen dataclass subclassing Component with no added fields or methods. This removes the Node/Component distinction entirely:
- Remove Node class, create_node(), and node-specific System methods (add_node, get_node, _nodes dict, nodes property) from network.py
- Remove Node from the public API (__init__.py)
- Remove nodes field from InputSystem (parsing.py)
- Simplify resolve_components.py to add former nodes as plain Components
- Move nodes: sections in all YAML system files into components:
- Update all test files to use Component instead of Node

https://claude.ai/code/session_01LFjwykkbWfw5Z89Y2c2QcW