### PR TITLE
Fix SimulationTable.to_csv mypy error in folder.py

### DIFF
--- a/src/gems/study/folder.py
+++ b/src/gems/study/folder.py
@@ -108,6 +108,6 @@ def run_study(
         timestamp = time.strftime("%Y%m%d-%H%M%S")
         output_file = output_dir / f"{study_dir.stem}_simulation_table_{timestamp}.csv"
 
-        df.to_csv(output_file, index=False)
+        df.data.to_csv(output_file, index=False)
 
     return problem


### PR DESCRIPTION
Access the underlying DataFrame via .data before calling to_csv, consistent with how SimulationTableWriter already does it.

https://claude.ai/code/session_01CCigNV7CZLfWa494aoftPQ