### PR TITLE
Rename components_input to system_input in examples (fixes #73)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -174,7 +174,7 @@ with open("system.yml") as lib_file:
     input_libraries = [parse_yaml_library(lib_file)]
 
 result_lib = resolve_library(input_libraries)
-components_input = resolve_system(input_system, result_lib)
+system_input = resolve_system(input_system, result_lib)
 database = build_data_base(input_system, Path(series_dir))
 ~~~
 
@@ -182,7 +182,7 @@ database = build_data_base(input_system, Path(series_dir))
 
 ~~~ python
 
-network = build_network(components_input)
+network = build_network(system_input)
 
 problem = build_problem(
     network,

--- a/docs/user-guide/inputs.md
+++ b/docs/user-guide/inputs.md
@@ -13,7 +13,7 @@ with open("simple_library.yml") as lib_file:
     input_libraries = [parse_yaml_library(lib_file)]
 
 result_lib = resolve_library(input_libraries)
-components_input = resolve_system(input_system, result_lib)
+system_input = resolve_system(input_system, result_lib)
 database = build_data_base(input_system, Path(series_dir))
 ~~~
 

--- a/docs/user-guide/optimisation.md
+++ b/docs/user-guide/optimisation.md
@@ -7,7 +7,7 @@
 
 ~~~ python
 
-network = build_network(components_input)
+network = build_network(system_input)
 
 problem = build_problem(
     network,

--- a/tests/e2e/functional/test_libs_yaml_system_yaml.py
+++ b/tests/e2e/functional/test_libs_yaml_system_yaml.py
@@ -58,13 +58,13 @@ def test_basic_balance_using_yaml(
     input_system: InputSystem, input_library: InputLibrary
 ) -> None:
     result_lib = resolve_library([input_library])
-    components_input = resolve_system(input_system, result_lib)
-    consistency_check(components_input, result_lib["basic"].models)
+    system_input = resolve_system(input_system, result_lib)
+    consistency_check(system_input, result_lib["basic"].models)
 
     database = build_data_base(input_system, None)
 
     scenarios = 1
-    problem = build_problem(components_input, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(system_input, database, TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3000

--- a/tests/e2e/models/andromede-v1/test_andromede_v1_models.py
+++ b/tests/e2e/models/andromede-v1/test_andromede_v1_models.py
@@ -124,12 +124,12 @@ def test_model_behaviour(
     with open(systems_dir / system_file) as compo_file:
         input_component = parse_yaml_components(compo_file)
     result_lib = resolve_library(input_libraries)
-    components_input = resolve_system(input_component, result_lib)
+    system_input = resolve_system(input_component, result_lib)
     database = build_data_base(input_component, Path(series_dir))
     reference_values = pd.read_csv(results_dir / optim_result_file, header=None).values
     for k in range(batch):
         problem = build_problem(
-            components_input,
+            system_input,
             database,
             TimeBlock(1, [i for i in range(k * timespan, (k + 1) * timespan)]),
             scenarios,

--- a/tests/e2e/models/operators/test_operators_v1.py
+++ b/tests/e2e/models/operators/test_operators_v1.py
@@ -104,7 +104,7 @@ def test_model_behaviour(
         input_component = parse_yaml_components(compo_file)
 
     result_lib = resolve_library(input_libraries)
-    components_input = resolve_system(input_component, result_lib)
+    system_input = resolve_system(input_component, result_lib)
     database = build_data_base(input_component, Path(series_dir))
     df_ref = pd.read_csv(results_dir / optim_result_file)
     expected_objective = df_ref[df_ref["output"] == "OBJECTIVE_VALUE"]["value"].iloc[0]
@@ -118,7 +118,7 @@ def test_model_behaviour(
 
     for _ in range(0, batch):
         problem = build_problem(
-            components_input,
+            system_input,
             database,
             TimeBlock(1, timesteps),
             scenarios,


### PR DESCRIPTION
Replace the variable name `components_input` with `system_input` in documentation code blocks and e2e test files. The variable holds the result of `resolve_system()` which returns a `System` object, so `system_input` better reflects its purpose.

Closes #73 
https://claude.ai/code/session_01EQRcsQub1W3Wx7L4qrQ8bh