### PR TITLE
Introduce Study container class to gather System and DataBase (closes…

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -185,8 +185,7 @@ database = build_data_base(input_system, Path(series_dir))
 network = build_network(system_input)
 
 problem = build_problem(
-    network,
-    database,
+    Study(network, database),
     TimeBlock(1, [i for i in range(0, timespan)]),
     scenarios,
 )

--- a/docs/user-guide/optimisation.md
+++ b/docs/user-guide/optimisation.md
@@ -10,8 +10,7 @@
 network = build_network(system_input)
 
 problem = build_problem(
-    network,
-    database,
+    Study(network, database),
     TimeBlock(1, [i for i in range(0, timespan)]),
     scenarios,
 )

--- a/src/gems/main/main.py
+++ b/src/gems/main/main.py
@@ -32,7 +32,7 @@ from gems.simulation import (
     build_problem,
     dump_couplings,
 )
-from gems.study import DataBase, System
+from gems.study import Study
 from gems.study.parsing import parse_cli, parse_yaml_components
 from gems.study.resolve_components import (
     build_data_base,
@@ -62,12 +62,12 @@ def input_libs(yaml_lib_paths: List[Path]) -> dict[str, Library]:
     return resolve_library(yaml_libraries)
 
 
-def input_database(study_path: Path, timeseries_path: Optional[Path]) -> DataBase:
+def input_database(study_path: Path, timeseries_path: Optional[Path]):
     with study_path.open() as comp:
         return build_data_base(parse_yaml_components(comp), timeseries_path)
 
 
-def input_study(study_path: Path, librairies: dict[str, Library]) -> System:
+def input_system(study_path: Path, librairies: dict[str, Library]):
     with study_path.open() as comp:
         return resolve_system(parse_yaml_components(comp), librairies)
 
@@ -84,13 +84,13 @@ def main_cli() -> None:
     parsed_args = parse_cli()
 
     lib_dict = input_libs(parsed_args.models_path)
-    study = input_study(parsed_args.components_path, lib_dict)
+    system = input_system(parsed_args.components_path, lib_dict)
 
     models = {}
     for lib in lib_dict.values():
         models.update(lib.models)
 
-    consistency_check(study, models)
+    consistency_check(system, models)
 
     try:
         database = input_database(
@@ -105,15 +105,17 @@ def main_cli() -> None:
     timeblock = TimeBlock(1, list(range(parsed_args.duration)))
     scenario = parsed_args.nb_scenarios
 
+    study = Study(system=system, database=database)
+
     # Load optional optim-config.yml
     optim_config = load_optim_config(parsed_args.components_path)
 
     if optim_config is not None:
-        validate_optim_config(optim_config, study)
+        validate_optim_config(optim_config, system)
 
         try:
             decomposed = build_decomposed_problems(
-                study, database, timeblock, scenario, optim_config
+                study, timeblock, scenario, optim_config
             )
         except IndexError as e:
             raise IndexError(
@@ -138,7 +140,7 @@ def main_cli() -> None:
     else:
         # No optim-config.yml — original unchanged behaviour
         try:
-            problem = build_problem(study, database, timeblock, scenario)
+            problem = build_problem(study, timeblock, scenario)
 
         except IndexError as e:
             raise IndexError(

--- a/src/gems/main/main.py
+++ b/src/gems/main/main.py
@@ -33,12 +33,14 @@ from gems.simulation import (
     dump_couplings,
 )
 from gems.study import Study
+from gems.study.data import DataBase
 from gems.study.parsing import parse_cli, parse_yaml_components
 from gems.study.resolve_components import (
     build_data_base,
     consistency_check,
     resolve_system,
 )
+from gems.study.system import System
 
 
 class AntaresTimeSeriesImportError(Exception):
@@ -62,12 +64,12 @@ def input_libs(yaml_lib_paths: List[Path]) -> dict[str, Library]:
     return resolve_library(yaml_libraries)
 
 
-def input_database(study_path: Path, timeseries_path: Optional[Path]):
+def input_database(study_path: Path, timeseries_path: Optional[Path]) -> DataBase:
     with study_path.open() as comp:
         return build_data_base(parse_yaml_components(comp), timeseries_path)
 
 
-def input_system(study_path: Path, librairies: dict[str, Library]):
+def input_system(study_path: Path, librairies: dict[str, Library]) -> System:
     with study_path.open() as comp:
         return resolve_system(parse_yaml_components(comp), librairies)
 

--- a/src/gems/simulation/optimization.py
+++ b/src/gems/simulation/optimization.py
@@ -50,6 +50,7 @@ from gems.simulation.linearize import (
 )
 from gems.simulation.time_block import TimeBlock
 from gems.study.data import ConstantData, DataBase, ScenarioSeriesData, TimeSeriesData
+from gems.study.study import Study
 from gems.study.system import Component, System
 
 if TYPE_CHECKING:
@@ -757,8 +758,7 @@ class _OptimizationProblemBuilder:
 
 
 def build_problem(
-    system: System,
-    database: DataBase,
+    study: Study,
     block: TimeBlock,
     scenarios: int,
     *,
@@ -770,10 +770,9 @@ def build_problem(
 
     Parameters
     ----------
-    system:
-        System of components and connections.
-    database:
-        Parameter data for all components.
+    study:
+        Container holding both the System (components and connections) and
+        the DataBase (parameter values for those components).
     block:
         The time block to optimize.
     scenarios:
@@ -789,12 +788,12 @@ def build_problem(
             "Only BlockBorderManagement.CYCLE is supported."
         )
 
-    database.requirements_consistency(system)
+    study.check_consistency()
 
     builder = _OptimizationProblemBuilder(
         name=problem_name,
-        system=system,
-        database=database,
+        system=study.system,
+        database=study.database,
         block=block,
         scenarios=scenarios,
     )
@@ -826,8 +825,7 @@ class DecomposedProblems:
 
 
 def build_decomposed_problems(
-    system: System,
-    database: DataBase,
+    study: Study,
     block: TimeBlock,
     scenarios: int,
     optim_config: "OptimConfig",
@@ -846,7 +844,10 @@ def build_decomposed_problems(
 
     Parameters
     ----------
-    system, database, block, scenarios:
+    study:
+        Container holding both the System and the DataBase.
+        Same semantics as :func:`build_problem`.
+    block, scenarios:
         Same semantics as :func:`build_problem`.
     optim_config:
         Parsed ``OptimConfig`` from an ``optim-config.yml`` file.
@@ -864,7 +865,7 @@ def build_decomposed_problems(
             "Only BlockBorderManagement.CYCLE is supported."
         )
 
-    database.requirements_consistency(system)
+    study.check_consistency()
 
     master_locs: Set["ElementLocation"] = {
         ElementLocation.MASTER,
@@ -877,8 +878,8 @@ def build_decomposed_problems(
 
     subproblem = _OptimizationProblemBuilder(
         name=subproblem_name,
-        system=system,
-        database=database,
+        system=study.system,
+        database=study.database,
         block=block,
         scenarios=scenarios,
         location_filter=DecompositionFilter(optim_config, sub_locs),
@@ -888,8 +889,8 @@ def build_decomposed_problems(
     if _has_any_master_element(optim_config):
         master = _OptimizationProblemBuilder(
             name=master_name,
-            system=system,
-            database=database,
+            system=study.system,
+            database=study.database,
             block=block,
             scenarios=scenarios,
             location_filter=DecompositionFilter(optim_config, master_locs),

--- a/src/gems/study/__init__.py
+++ b/src/gems/study/__init__.py
@@ -21,4 +21,5 @@ from .data import (
     TimeScenarioSeriesData,
     TimeSeriesData,
 )
+from .study import Study
 from .system import Component, PortRef, PortsConnection, System, create_component

--- a/src/gems/study/data.py
+++ b/src/gems/study/data.py
@@ -17,8 +17,6 @@ from typing import Dict, List, Mapping, Optional, Union
 import numpy as np
 import pandas as pd
 
-from gems.study.system import System
-
 
 @dataclass(frozen=True)
 class TimeScenarioIndex:
@@ -251,15 +249,3 @@ class DataBase:
         else:
             raise KeyError(f"Index {index} not found.")
 
-    def requirements_consistency(self, system: System) -> None:
-        for component in system.components:
-            for param in component.model.parameters.values():
-                data_structure = self.get_data(component.id, param.name)
-
-                if not data_structure.check_requirement(
-                    component.model.parameters[param.name].structure.time,
-                    component.model.parameters[param.name].structure.scenario,
-                ):
-                    raise ValueError(
-                        f"Data inconsistency for component: {component.id}, parameter: {param.name}. Requirement not met."
-                    )

--- a/src/gems/study/data.py
+++ b/src/gems/study/data.py
@@ -248,4 +248,3 @@ class DataBase:
             return self._data[index].get_value([timestep], scenario)
         else:
             raise KeyError(f"Index {index} not found.")
-

--- a/src/gems/study/folder.py
+++ b/src/gems/study/folder.py
@@ -19,9 +19,8 @@ from gems.model.resolve_library import resolve_library
 from gems.optim_config import load_optim_config
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.optimization import OptimizationProblem
-from gems.study.data import DataBase
-from gems.study.system import System
 from gems.study.parsing import parse_yaml_components
+from gems.study.study import Study
 from gems.study.resolve_components import (
     build_data_base,
     consistency_check,
@@ -29,7 +28,7 @@ from gems.study.resolve_components import (
 )
 
 
-def load_study(study_dir: Path) -> tuple[System, DataBase]:
+def load_study(study_dir: Path) -> Study:
     """
     Loads a study from a given directory.
 
@@ -41,7 +40,7 @@ def load_study(study_dir: Path) -> tuple[System, DataBase]:
         study_dir: The path to the study directory.
 
     Returns:
-        A tuple containing the simulation system and the database.
+        A Study container holding the resolved system and database.
     """
     system_file = study_dir / "input" / "system.yml"
     lib_folder = study_dir / "input" / "model-libraries"
@@ -70,7 +69,7 @@ def load_study(study_dir: Path) -> tuple[System, DataBase]:
     consistency_check(system, model_dict)
 
     database = build_data_base(input_study, series_dir)
-    return system, database
+    return Study(system=system, database=database)
 
 
 def run_study(
@@ -94,8 +93,8 @@ def run_study(
         The solved simulation problem.
     """
 
-    system, database = load_study(study_dir)
-    problem = build_problem(system, database, time_block, scenarios)
+    study = load_study(study_dir)
+    problem = build_problem(study, time_block, scenarios)
     problem.solve()
     if export_simulation_table:
         from gems.simulation.simulation_table import SimulationTableBuilder

--- a/src/gems/study/folder.py
+++ b/src/gems/study/folder.py
@@ -20,12 +20,12 @@ from gems.optim_config import load_optim_config
 from gems.simulation import TimeBlock, build_problem
 from gems.simulation.optimization import OptimizationProblem
 from gems.study.parsing import parse_yaml_components
-from gems.study.study import Study
 from gems.study.resolve_components import (
     build_data_base,
     consistency_check,
     resolve_system,
 )
+from gems.study.study import Study
 
 
 def load_study(study_dir: Path) -> Study:

--- a/src/gems/study/study.py
+++ b/src/gems/study/study.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+from dataclasses import dataclass
+
+from gems.study.data import DataBase
+from gems.study.system import System
+
+
+@dataclass
+class Study:
+    """
+    Container that pairs a System (component topology and connections) with a
+    DataBase (parameter values for those components).
+
+    These two objects are always used together to build an optimisation
+    problem.  ``Study`` gathers them into a single, coherent unit and
+    provides the cross-validation logic that was previously spread between
+    ``DataBase.requirements_consistency`` and the callers of
+    ``build_problem``.
+    """
+
+    system: System
+    database: DataBase
+
+    def check_consistency(self) -> None:
+        """Validate that the database supplies data for every parameter of every
+        component defined in the system.
+
+        Raises
+        ------
+        ValueError
+            If a required data entry is missing or its time/scenario structure
+            does not match what the model parameter expects.
+        """
+        for component in self.system.components:
+            for param in component.model.parameters.values():
+                data_structure = self.database.get_data(component.id, param.name)
+
+                if not data_structure.check_requirement(
+                    component.model.parameters[param.name].structure.time,
+                    component.model.parameters[param.name].structure.scenario,
+                ):
+                    raise ValueError(
+                        f"Data inconsistency for component: {component.id}, "
+                        f"parameter: {param.name}. Requirement not met."
+                    )

--- a/tests/e2e/functional/perf_pypsa.py
+++ b/tests/e2e/functional/perf_pypsa.py
@@ -8,6 +8,7 @@ import pandas as pd
 from gems.model.parsing import parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import TimeBlock, build_problem
+from gems.study import Study
 from gems.study.data import DataBase
 from gems.study.parsing import parse_yaml_components
 from gems.study.resolve_components import (
@@ -39,7 +40,7 @@ def build_pypsa_problem(system: System, database: DataBase, time_horizon: int) -
     scenarios = 1
     time_block = TimeBlock(1, list(range(time_horizon)))
     start = time.time()
-    problem = build_problem(system, database, time_block, scenarios)
+    problem = build_problem(Study(system, database), time_block, scenarios)
     end = time.time()
     print(f"Time elapsed for horizon {time_horizon}: {end - start:.4f}")
     return end - start

--- a/tests/e2e/functional/test_component_dependent_time_shift.py
+++ b/tests/e2e/functional/test_component_dependent_time_shift.py
@@ -96,7 +96,7 @@ from gems.study import (
     System,
     TimeScenarioSeriesData,
     create_component,
-)
+    Study,)
 from gems.study.parsing import parse_yaml_components
 from gems.study.resolve_components import (
     build_data_base,
@@ -240,8 +240,7 @@ def test_single_lag2_forced_odd_spillage() -> None:
 
     system = _build_system("STS")
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         TimeBlock(1, list(range(horizon))),
         scenarios=1,
         border_management=BlockBorderManagement.CYCLE,
@@ -295,8 +294,7 @@ def test_two_components_different_lags_asymmetric_demand() -> None:
 
     system = _build_system("STS1", "STS2")
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         TimeBlock(1, list(range(horizon))),
         scenarios=1,
         border_management=BlockBorderManagement.CYCLE,
@@ -357,8 +355,7 @@ def test_three_components_distinct_lags_orbit_spillage() -> None:
 
     system = _build_system("STS1", "STS2", "STS3")
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         TimeBlock(1, list(range(horizon))),
         scenarios=1,
         border_management=BlockBorderManagement.CYCLE,
@@ -423,8 +420,7 @@ def test_two_components_different_lags_yaml(
     database = build_data_base(input_system, timeseries_dir=_series_dir)
 
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         TimeBlock(1, list(range(4))),
         scenarios=1,
         border_management=BlockBorderManagement.CYCLE,

--- a/tests/e2e/functional/test_component_dependent_time_shift.py
+++ b/tests/e2e/functional/test_component_dependent_time_shift.py
@@ -93,10 +93,11 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     TimeScenarioSeriesData,
     create_component,
-    Study,)
+)
 from gems.study.parsing import parse_yaml_components
 from gems.study.resolve_components import (
     build_data_base,

--- a/tests/e2e/functional/test_investment.py
+++ b/tests/e2e/functional/test_investment.py
@@ -37,10 +37,11 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     TimeScenarioSeriesData,
     create_component,
-    Study,)
+)
 from tests.e2e.functional.libs.standard import (
     BALANCE_PORT_TYPE,
     CONSTANT,

--- a/tests/e2e/functional/test_investment.py
+++ b/tests/e2e/functional/test_investment.py
@@ -40,7 +40,7 @@ from gems.study import (
     System,
     TimeScenarioSeriesData,
     create_component,
-)
+    Study,)
 from tests.e2e.functional.libs.standard import (
     BALANCE_PORT_TYPE,
     CONSTANT,
@@ -216,8 +216,7 @@ def test_generation_xpansion_single_time_step_single_scenario(
 
     scenarios = 1
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         TimeBlock(1, [0]),
         scenarios,
     )
@@ -293,7 +292,7 @@ def test_two_candidates_xpansion_single_time_step_single_scenario(
     )
     scenarios = 1
 
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
 
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
@@ -378,7 +377,7 @@ def test_generation_xpansion_two_time_steps_two_scenarios(
     system.connect(PortRef(generator, "balance_port"), PortRef(node, "balance_port"))
     system.connect(PortRef(candidate, "balance_port"), PortRef(node, "balance_port"))
 
-    problem = build_problem(system, database, time_block, scenarios)
+    problem = build_problem(Study(system, database), time_block, scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     # assert problem.solver.NumVariables() == 2 * scenarios * horizon + 1

--- a/tests/e2e/functional/test_libs_python_system_python.py
+++ b/tests/e2e/functional/test_libs_python_system_python.py
@@ -51,7 +51,7 @@ from gems.study import (
     TimeScenarioIndex,
     TimeScenarioSeriesData,
     create_component,
-)
+    Study,)
 from tests.e2e.functional.libs.standard import (
     BALANCE_PORT_TYPE,
     DEMAND_MODEL,
@@ -93,7 +93,7 @@ def test_basic_balance() -> None:
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "balance_port"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3000
@@ -141,7 +141,7 @@ def test_timeseries() -> None:
     time_block = TimeBlock(1, [0, 1])
     scenarios = 1
 
-    problem = build_problem(system, database, time_block, scenarios)
+    problem = build_problem(Study(system, database), time_block, scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 100 * 30 + 50 * 30
@@ -212,20 +212,20 @@ def test_variable_bound() -> None:
 
     system = create_one_node_network(generator_model)
     database = create_simple_database(max_generation=200)
-    problem = build_problem(system, database, TimeBlock(1, [0]), 1)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), 1)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3000
 
     system = create_one_node_network(generator_model)
     database = create_simple_database(max_generation=80)
-    problem = build_problem(system, database, TimeBlock(1, [0]), 1)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), 1)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "infeasible"  # Infeasible
 
     system = create_one_node_network(generator_model)
     database = create_simple_database(max_generation=0)  # Equal upper and lower bounds
-    problem = build_problem(system, database, TimeBlock(1, [0]), 1)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), 1)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "infeasible"
 
@@ -235,7 +235,7 @@ def test_variable_bound() -> None:
         ValueError,
         match=r"Upper bound \(-10\) must be strictly greater than lower bound \(0\) for variable G.generation",
     ):
-        problem = build_problem(system, database, TimeBlock(1, [0]), 1)
+        problem = build_problem(Study(system, database), TimeBlock(1, [0]), 1)
 
 
 def generate_data(
@@ -296,8 +296,7 @@ def short_term_storage_base(efficiency: float, horizon: int) -> None:
     system.connect(PortRef(unsupplied, "balance_port"), PortRef(node, "balance_port"))
 
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         time_blocks[0],
         scenarios,
         border_management=BlockBorderManagement.CYCLE,

--- a/tests/e2e/functional/test_libs_python_system_python.py
+++ b/tests/e2e/functional/test_libs_python_system_python.py
@@ -47,11 +47,12 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     TimeScenarioIndex,
     TimeScenarioSeriesData,
     create_component,
-    Study,)
+)
 from tests.e2e.functional.libs.standard import (
     BALANCE_PORT_TYPE,
     DEMAND_MODEL,

--- a/tests/e2e/functional/test_libs_yaml_system_python.py
+++ b/tests/e2e/functional/test_libs_yaml_system_python.py
@@ -40,10 +40,11 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     TimeScenarioSeriesData,
     create_component,
-    Study,)
+)
 
 # TODO : Use fixtures for models and components used several times to simplify this test file
 

--- a/tests/e2e/functional/test_libs_yaml_system_python.py
+++ b/tests/e2e/functional/test_libs_yaml_system_python.py
@@ -43,7 +43,7 @@ from gems.study import (
     System,
     TimeScenarioSeriesData,
     create_component,
-)
+    Study,)
 
 # TODO : Use fixtures for models and components used several times to simplify this test file
 
@@ -82,7 +82,7 @@ def test_basic_balance(lib_dict: dict[str, Library]) -> None:
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "balance_port"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3000
@@ -133,7 +133,7 @@ def test_link(lib_dict: dict[str, Library]) -> None:
     system.connect(PortRef(link, "out_port"), PortRef(node2, "balance_port"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3500
@@ -186,7 +186,7 @@ def test_stacking_generation(lib_dict: dict[str, Library]) -> None:
     system.connect(PortRef(gen2, "balance_port"), PortRef(node1, "balance_port"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 30 * 100 + 50 * 50
@@ -225,7 +225,7 @@ def test_spillage(lib_dict: dict[str, Library]) -> None:
     system.connect(PortRef(gen1, "balance_port"), PortRef(node, "balance_port"))
     system.connect(PortRef(spillage, "balance_port"), PortRef(node, "balance_port"))
 
-    problem = build_problem(system, database, TimeBlock(0, [1]), 1)
+    problem = build_problem(Study(system, database), TimeBlock(0, [1]), 1)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 30 * 200 + 50 * 10
@@ -311,8 +311,7 @@ def test_min_up_down_times(lib_dict: dict[str, Library]) -> None:
     )
 
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         time_block,
         scenarios,
         border_management=BlockBorderManagement.CYCLE,
@@ -367,8 +366,7 @@ def test_changing_demand(lib_dict: dict[str, Library]) -> None:
     system.connect(PortRef(prod, "balance_port"), PortRef(node, "balance_port"))
 
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         time_block,
         scenarios,
         border_management=BlockBorderManagement.CYCLE,
@@ -458,8 +456,7 @@ def test_min_up_down_times_2(lib_dict: dict[str, Library]) -> None:
     )
 
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         time_block,
         scenarios,
         border_management=BlockBorderManagement.CYCLE,

--- a/tests/e2e/functional/test_libs_yaml_system_yaml.py
+++ b/tests/e2e/functional/test_libs_yaml_system_yaml.py
@@ -60,12 +60,12 @@ def test_basic_balance_using_yaml(
 ) -> None:
     result_lib = resolve_library([input_library])
     system = resolve_system(input_system, result_lib)
-    consistency_check(system_input, result_lib["basic"].models)
+    consistency_check(system, result_lib["basic"].models)
 
     database = build_data_base(input_system, None)
 
     scenarios = 1
-    problem = build_problem(Study(study, database), TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3000
@@ -74,8 +74,8 @@ def test_basic_balance_using_yaml(
 @pytest.fixture
 def setup_test(
     libs_dir: Path, systems_dir: Path, series_dir: Path
-) -> Callable[[], Study:
-    def _setup_test(study_file_name: str):
+) -> Callable[[str], Study]:
+    def _setup_test(study_file_name: str) -> Study:
         study_file = systems_dir / study_file_name
         lib_file = libs_dir / "lib_unittest.yml"
         with lib_file.open() as lib:
@@ -85,7 +85,7 @@ def setup_test(
             input_system = parse_yaml_components(c)
         lib_dict = resolve_library([input_library])
         system = resolve_system(input_system, lib_dict)
-        consistency_check(study, lib_dict["basic"].models)
+        consistency_check(system, lib_dict["basic"].models)
 
         database = build_data_base(input_system, series_dir)
         return Study(system, database)
@@ -94,7 +94,7 @@ def setup_test(
 
 
 def test_basic_balance_time_only_series(
-    setup_test: Callable[[], Study,
+    setup_test: Callable[[str], Study],
 ) -> None:
     study = setup_test("study_time_only_series.yml")
     scenarios = 1
@@ -105,7 +105,7 @@ def test_basic_balance_time_only_series(
 
 
 def test_basic_balance_scenario_only_series(
-    setup_test: Callable[[], Study,
+    setup_test: Callable[[str], Study],
 ) -> None:
     study = setup_test("study_scenario_only_series.yml")
     scenarios = 2
@@ -116,7 +116,7 @@ def test_basic_balance_scenario_only_series(
 
 
 def test_short_term_storage_base_with_yaml(
-    setup_test: Callable[[], Study,
+    setup_test: Callable[[str], Study],
 ) -> None:
     study = setup_test("components_for_short_term_storage.yml")
     # 18 produced in the 1st time-step, then consumed 2 * efficiency in the rest
@@ -141,7 +141,7 @@ def test_short_term_storage_base_with_yaml(
 
 
 def test_varying_down_time(
-    setup_test: Callable[[], Study,
+    setup_test: Callable[[str], Study],
 ) -> None:
     """
     Two thermal clusters with different min-down-times actually start and stop,

--- a/tests/e2e/functional/test_libs_yaml_system_yaml.py
+++ b/tests/e2e/functional/test_libs_yaml_system_yaml.py
@@ -51,6 +51,7 @@ from gems.study.resolve_components import (
     consistency_check,
     resolve_system,
 )
+from gems.study.study import Study
 from gems.study.system import System
 
 
@@ -58,13 +59,13 @@ def test_basic_balance_using_yaml(
     input_system: InputSystem, input_library: InputLibrary
 ) -> None:
     result_lib = resolve_library([input_library])
-    system_input = resolve_system(input_system, result_lib)
+    system = resolve_system(input_system, result_lib)
     consistency_check(system_input, result_lib["basic"].models)
 
     database = build_data_base(input_system, None)
 
     scenarios = 1
-    problem = build_problem(Study(system_input, database), TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(study, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3000
@@ -73,7 +74,7 @@ def test_basic_balance_using_yaml(
 @pytest.fixture
 def setup_test(
     libs_dir: Path, systems_dir: Path, series_dir: Path
-) -> Callable[[], Tuple[System, DataBase]]:
+) -> Callable[[], Study:
     def _setup_test(study_file_name: str):
         study_file = systems_dir / study_file_name
         lib_file = libs_dir / "lib_unittest.yml"
@@ -81,51 +82,50 @@ def setup_test(
             input_library = parse_yaml_library(lib)
 
         with study_file.open() as c:
-            input_study = parse_yaml_components(c)
+            input_system = parse_yaml_components(c)
         lib_dict = resolve_library([input_library])
-        network_components = resolve_system(input_study, lib_dict)
-        consistency_check(network_components, lib_dict["basic"].models)
+        system = resolve_system(input_system, lib_dict)
+        consistency_check(study, lib_dict["basic"].models)
 
-        database = build_data_base(input_study, series_dir)
-        return network_components, database
+        database = build_data_base(input_system, series_dir)
+        return Study(system, database)
 
     return _setup_test
 
 
 def test_basic_balance_time_only_series(
-    setup_test: Callable[[], Tuple[System, DataBase]],
+    setup_test: Callable[[], Study,
 ) -> None:
-    system, database = setup_test("study_time_only_series.yml")
+    study = setup_test("study_time_only_series.yml")
     scenarios = 1
-    problem = build_problem(Study(system, database), TimeBlock(1, [0, 1]), scenarios)
+    problem = build_problem(study, TimeBlock(1, [0, 1]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 10000
 
 
 def test_basic_balance_scenario_only_series(
-    setup_test: Callable[[], Tuple[System, DataBase]],
+    setup_test: Callable[[], Study,
 ) -> None:
-    system, database = setup_test("study_scenario_only_series.yml")
+    study = setup_test("study_scenario_only_series.yml")
     scenarios = 2
-    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
+    problem = build_problem(study, TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 0.5 * 5000 + 0.5 * 10000
 
 
 def test_short_term_storage_base_with_yaml(
-    setup_test: Callable[[], Tuple[System, DataBase]],
+    setup_test: Callable[[], Study,
 ) -> None:
-    system, database = setup_test("components_for_short_term_storage.yml")
+    study = setup_test("components_for_short_term_storage.yml")
     # 18 produced in the 1st time-step, then consumed 2 * efficiency in the rest
     scenarios = 1
     horizon = 10
     time_blocks = [TimeBlock(0, list(range(horizon)))]
 
     problem = build_problem(
-        system,
-        database,
+        study,
         time_blocks[0],
         scenarios,
         border_management=BlockBorderManagement.CYCLE,
@@ -141,7 +141,7 @@ def test_short_term_storage_base_with_yaml(
 
 
 def test_varying_down_time(
-    setup_test: Callable[[], Tuple[System, DataBase]],
+    setup_test: Callable[[], Study,
 ) -> None:
     """
     Two thermal clusters with different min-down-times actually start and stop,
@@ -169,13 +169,12 @@ def test_varying_down_time(
       G_2: 2 steps × 50 × 50 =  5000
       Total                   = 12250
     """
-    system, database = setup_test("system_with_varying_down_time.yml")
+    study = setup_test("system_with_varying_down_time.yml")
     scenarios = 1
     horizon = 10
 
     problem = build_problem(
-        system,
-        database,
+        study,
         TimeBlock(0, list(range(horizon))),
         scenarios,
         border_management=BlockBorderManagement.CYCLE,

--- a/tests/e2e/functional/test_libs_yaml_system_yaml.py
+++ b/tests/e2e/functional/test_libs_yaml_system_yaml.py
@@ -64,7 +64,7 @@ def test_basic_balance_using_yaml(
     database = build_data_base(input_system, None)
 
     scenarios = 1
-    problem = build_problem(system_input, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system_input, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3000
@@ -97,7 +97,7 @@ def test_basic_balance_time_only_series(
 ) -> None:
     system, database = setup_test("study_time_only_series.yml")
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0, 1]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0, 1]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 10000
@@ -108,7 +108,7 @@ def test_basic_balance_scenario_only_series(
 ) -> None:
     system, database = setup_test("study_scenario_only_series.yml")
     scenarios = 2
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 0.5 * 5000 + 0.5 * 10000

--- a/tests/e2e/functional/test_performance.py
+++ b/tests/e2e/functional/test_performance.py
@@ -27,7 +27,7 @@ from gems.study import (
     PortRef,
     System,
     create_component,
-)
+    Study,)
 from gems.study.data import TimeScenarioSeriesData
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,
@@ -76,7 +76,7 @@ def test_large_sum_inside_model_with_loop() -> None:
     cost_model = create_component(model=SIMPLE_COST_MODEL, id="simple_cost")
     system.add_component(cost_model)
 
-    problem = build_problem(system, database, time_blocks[0], scenarios)
+    problem = build_problem(Study(system, database), time_blocks[0], scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert math.isclose(
@@ -111,7 +111,7 @@ def test_large_sum_outside_model_with_loop() -> None:
     )
     system.add_component(simple_model)
 
-    problem = build_problem(system, database, time_blocks[0], scenarios)
+    problem = build_problem(Study(system, database), time_blocks[0], scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == obj_coeff
@@ -158,7 +158,7 @@ def test_large_sum_inside_model_with_sum_operator() -> None:
     cost_model = create_component(model=SIMPLE_COST_MODEL, id="simple_cost")
     system.add_component(cost_model)
 
-    problem = build_problem(system, database, time_blocks[0], scenarios)
+    problem = build_problem(Study(system, database), time_blocks[0], scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3 * nb_terms
@@ -200,7 +200,7 @@ def test_large_sum_of_port_connections() -> None:
             PortRef(generators[gen_id], "balance_port"), PortRef(node, "balance_port")
         )
 
-    problem = build_problem(system, database, time_block, scenarios)
+    problem = build_problem(Study(system, database), time_block, scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 5 * nb_generators
@@ -236,7 +236,7 @@ def test_basic_balance_on_whole_year() -> None:
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "balance_port"))
 
     with cProfile.Profile() as pr:
-        problem = build_problem(system, database, time_block, scenarios)
+        problem = build_problem(Study(system, database), time_block, scenarios)
         pr.print_stats(sort=SortKey.CUMULATIVE)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
@@ -274,7 +274,7 @@ def test_basic_balance_on_whole_year_with_large_sum() -> None:
     system.connect(PortRef(demand, "balance_port"), PortRef(node, "balance_port"))
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "balance_port"))
 
-    problem = build_problem(system, database, time_block, scenarios)
+    problem = build_problem(Study(system, database), time_block, scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 30 * 100 * horizon

--- a/tests/e2e/functional/test_performance.py
+++ b/tests/e2e/functional/test_performance.py
@@ -25,9 +25,10 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     create_component,
-    Study,)
+)
 from gems.study.data import TimeScenarioSeriesData
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,

--- a/tests/e2e/functional/test_scalability.py
+++ b/tests/e2e/functional/test_scalability.py
@@ -9,10 +9,11 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     TimeScenarioSeriesData,
     create_component,
-    Study,)
+)
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,
     GENERATOR_MODEL_WITH_STORAGE,

--- a/tests/e2e/functional/test_scalability.py
+++ b/tests/e2e/functional/test_scalability.py
@@ -12,7 +12,7 @@ from gems.study import (
     System,
     TimeScenarioSeriesData,
     create_component,
-)
+    Study,)
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,
     GENERATOR_MODEL_WITH_STORAGE,
@@ -69,7 +69,7 @@ def build_for_horizon(horizon_size: int, scenario_count: int) -> float:
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "balance_port"))
 
     start = time.time()
-    problem = build_problem(system, database, time_block, scenarios)
+    problem = build_problem(Study(system, database), time_block, scenarios)
     end = time.time()
     print(f"Time elapsed for horizon {horizon_size}: {end - start:.4f}")
     return end - start

--- a/tests/e2e/functional/test_scenario_builder.py
+++ b/tests/e2e/functional/test_scenario_builder.py
@@ -19,8 +19,8 @@ from gems.model.parsing import parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import build_problem
 from gems.simulation.time_block import TimeBlock
-from gems.study.data import DataBase
 from gems.study import Study
+from gems.study.data import DataBase
 from gems.study.parsing import parse_scenario_builder, parse_yaml_components
 from gems.study.resolve_components import (
     build_scenarized_data_base,

--- a/tests/e2e/functional/test_scenario_builder.py
+++ b/tests/e2e/functional/test_scenario_builder.py
@@ -20,6 +20,7 @@ from gems.model.resolve_library import resolve_library
 from gems.simulation import build_problem
 from gems.simulation.time_block import TimeBlock
 from gems.study.data import DataBase
+from gems.study import Study
 from gems.study.parsing import parse_scenario_builder, parse_yaml_components
 from gems.study.resolve_components import (
     build_scenarized_data_base,
@@ -61,7 +62,7 @@ def test_system_with_scenarization(
     consistency_check(components, lib_dict["basic"].models)
 
     timeblock = TimeBlock(1, list(range(2)))
-    problem = build_problem(components, database, timeblock, 3)
+    problem = build_problem(Study(components, database), timeblock, 3)
 
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"

--- a/tests/e2e/functional/test_stochastic.py
+++ b/tests/e2e/functional/test_stochastic.py
@@ -21,9 +21,10 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     create_component,
-    Study,)
+)
 from gems.study.data import TimeScenarioSeriesData
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,

--- a/tests/e2e/functional/test_stochastic.py
+++ b/tests/e2e/functional/test_stochastic.py
@@ -23,7 +23,7 @@ from gems.study import (
     PortRef,
     System,
     create_component,
-)
+    Study,)
 from gems.study.data import TimeScenarioSeriesData
 from tests.e2e.functional.libs.standard import (
     DEMAND_MODEL,
@@ -132,7 +132,7 @@ def test_stochastic_model_with_HD_for_thermal_startup(
     system.connect(PortRef(peak, "balance_port"), PortRef(node, "balance_port"))
 
     for block in time_blocks:  # TODO : To manage blocks simply for now
-        problem = build_problem(system, database, block, scenarios)
+        problem = build_problem(Study(system, database), block, scenarios)
         problem.solve(solver_name="highs")
         assert (
             problem.termination_condition == "optimal"
@@ -188,7 +188,7 @@ def test_stochastic_model_with_DH_for_thermal_startup(
     system.connect(PortRef(peak, "balance_port"), PortRef(node, "balance_port"))
 
     for block in time_blocks:  # TODO : To manage blocks simply for now
-        problem = build_problem(system, database, block, scenarios)
+        problem = build_problem(Study(system, database), block, scenarios)
         problem.solve(solver_name="highs")
         assert (
             problem.termination_condition == "optimal"

--- a/tests/e2e/functional/test_study_from_folder.py
+++ b/tests/e2e/functional/test_study_from_folder.py
@@ -7,10 +7,10 @@ from gems.study.folder import load_study, run_study
 def test_load_study():
     study_dir = Path(__file__).parent / "studies" / "7_4"
 
-    system, database = load_study(study_dir)
-    assert len(system.components) == 12
-    assert len(system.connections) == 11
-    assert len(database._data) == 76
+    study = load_study(study_dir)
+    assert len(study.system.components) == 12
+    assert len(study.system.connections) == 11
+    assert len(study.database._data) == 76
 
 
 def test_run_study():

--- a/tests/e2e/models/andromede-v1/test_andromede_v1_models.py
+++ b/tests/e2e/models/andromede-v1/test_andromede_v1_models.py
@@ -20,6 +20,7 @@ import pytest
 from gems.model.parsing import InputLibrary, parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import build_problem
+from gems.study import Study
 from gems.simulation.time_block import TimeBlock
 from gems.study.parsing import parse_yaml_components
 from gems.study.resolve_components import build_data_base, resolve_system
@@ -129,8 +130,7 @@ def test_model_behaviour(
     reference_values = pd.read_csv(results_dir / optim_result_file, header=None).values
     for k in range(batch):
         problem = build_problem(
-            system_input,
-            database,
+            Study(system_input, database),
             TimeBlock(1, [i for i in range(k * timespan, (k + 1) * timespan)]),
             scenarios,
         )

--- a/tests/e2e/models/andromede-v1/test_andromede_v1_models.py
+++ b/tests/e2e/models/andromede-v1/test_andromede_v1_models.py
@@ -20,8 +20,8 @@ import pytest
 from gems.model.parsing import InputLibrary, parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import build_problem
-from gems.study import Study
 from gems.simulation.time_block import TimeBlock
+from gems.study import Study
 from gems.study.parsing import parse_yaml_components
 from gems.study.resolve_components import build_data_base, resolve_system
 

--- a/tests/e2e/models/operators/test_operators_v1.py
+++ b/tests/e2e/models/operators/test_operators_v1.py
@@ -20,9 +20,9 @@ import pytest
 from gems.model.parsing import InputLibrary, parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import build_problem
-from gems.study import Study
 from gems.simulation.simulation_table import SimulationTableBuilder
 from gems.simulation.time_block import TimeBlock
+from gems.study import Study
 from gems.study.parsing import parse_yaml_components
 from gems.study.resolve_components import build_data_base, resolve_system
 

--- a/tests/e2e/models/operators/test_operators_v1.py
+++ b/tests/e2e/models/operators/test_operators_v1.py
@@ -20,6 +20,7 @@ import pytest
 from gems.model.parsing import InputLibrary, parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import build_problem
+from gems.study import Study
 from gems.simulation.simulation_table import SimulationTableBuilder
 from gems.simulation.time_block import TimeBlock
 from gems.study.parsing import parse_yaml_components
@@ -118,8 +119,7 @@ def test_model_behaviour(
 
     for _ in range(0, batch):
         problem = build_problem(
-            system_input,
-            database,
+            Study(system_input, database),
             TimeBlock(1, timesteps),
             scenarios,
         )

--- a/tests/e2e/models/poc-various-models/test_ac_link.py
+++ b/tests/e2e/models/poc-various-models/test_ac_link.py
@@ -26,7 +26,7 @@ from gems.study import (
     PortRef,
     System,
     create_component,
-)
+    Study,)
 
 
 @pytest.fixture
@@ -81,7 +81,7 @@ def test_ac_network_no_links(ac_lib: dict[str, Library]) -> None:
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "injections"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == pytest.approx(3000, abs=0.01)
@@ -137,7 +137,7 @@ def test_ac_network(ac_lib: dict[str, Library]) -> None:
     system.connect(PortRef(link, "port2"), PortRef(node2, "links"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == pytest.approx(3500, abs=0.01)
@@ -206,7 +206,7 @@ def test_parallel_ac_links(ac_lib: dict[str, Library]) -> None:
     system.connect(PortRef(link2, "port2"), PortRef(node2, "links"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == pytest.approx(3500, abs=0.01)
@@ -283,7 +283,7 @@ def test_parallel_ac_links_with_pst(ac_lib: dict[str, Library]) -> None:
     system.connect(PortRef(link2, "port2"), PortRef(node2, "links"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == pytest.approx(3550, abs=0.01)

--- a/tests/e2e/models/poc-various-models/test_ac_link.py
+++ b/tests/e2e/models/poc-various-models/test_ac_link.py
@@ -24,9 +24,10 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     create_component,
-    Study,)
+)
 
 
 @pytest.fixture

--- a/tests/e2e/models/poc-various-models/test_electrolyzer.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer.py
@@ -32,7 +32,7 @@ from gems.study import (
     PortRef,
     System,
     create_component,
-)
+    Study,)
 
 ELECTRICAL_PORT = PortType(id="electrical_port", fields=[PortField("flow")])
 
@@ -172,7 +172,7 @@ def test_electrolyzer() -> None:
     )
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == 3000

--- a/tests/e2e/models/poc-various-models/test_electrolyzer.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer.py
@@ -30,9 +30,10 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     create_component,
-    Study,)
+)
 
 ELECTRICAL_PORT = PortType(id="electrical_port", fields=[PortField("flow")])
 

--- a/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs.py
@@ -30,7 +30,7 @@ from gems.study import (
     PortRef,
     System,
     create_component,
-)
+    Study,)
 
 """
 This file tests various modellings for an electrolyser with multiple inputs. The models are created in Python directly.
@@ -124,7 +124,7 @@ def test_electrolyzer_n_inputs_1() -> None:
     system.connect(PortRef(gaz_prod, "balance_port"), PortRef(gaz_node, "balance_port"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
 
     assert problem.termination_condition == "optimal"
@@ -213,7 +213,7 @@ def test_electrolyzer_n_inputs_2() -> None:
     system.connect(PortRef(gaz_prod, "balance_port"), PortRef(gaz_node, "balance_port"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
 
     assert problem.termination_condition == "optimal"
@@ -311,7 +311,7 @@ def test_electrolyzer_n_inputs_3() -> None:
     system.connect(PortRef(gaz_prod, "balance_port"), PortRef(gaz_node, "balance_port"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
 
     assert problem.termination_condition == "optimal"
@@ -400,7 +400,7 @@ def test_electrolyzer_n_inputs_4() -> None:
     system.connect(PortRef(gaz_prod, "balance_port"), PortRef(gaz_node, "balance_port"))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
 

--- a/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs.py
@@ -28,9 +28,10 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     create_component,
-    Study,)
+)
 
 """
 This file tests various modellings for an electrolyser with multiple inputs. The models are created in Python directly.

--- a/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs_yaml.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs_yaml.py
@@ -22,7 +22,7 @@ from gems.study import (
     PortRef,
     System,
     create_component,
-)
+    Study,)
 
 """
 This file tests various modellings for an electrolyser with multiple inputs. The models are read from a YAML model file.
@@ -132,7 +132,7 @@ def test_electrolyzer_n_inputs_1(
     )
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
 
     assert problem.termination_condition == "optimal"
@@ -234,7 +234,7 @@ def test_electrolyzer_n_inputs_2(
     )
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
 
     assert problem.termination_condition == "optimal"
@@ -348,7 +348,7 @@ def test_electrolyzer_n_inputs_3(
     )
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
 
     assert problem.termination_condition == "optimal"
@@ -452,7 +452,7 @@ def test_electrolyzer_n_inputs_4(
     )
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
 

--- a/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs_yaml.py
+++ b/tests/e2e/models/poc-various-models/test_electrolyzer_n_inputs_yaml.py
@@ -20,9 +20,10 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     create_component,
-    Study,)
+)
 
 """
 This file tests various modellings for an electrolyser with multiple inputs. The models are read from a YAML model file.

--- a/tests/e2e/models/poc-various-models/test_quota_co2.py
+++ b/tests/e2e/models/poc-various-models/test_quota_co2.py
@@ -26,9 +26,10 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     create_component,
-    Study,)
+)
 
 
 def test_quota_co2() -> None:

--- a/tests/e2e/models/poc-various-models/test_quota_co2.py
+++ b/tests/e2e/models/poc-various-models/test_quota_co2.py
@@ -28,7 +28,7 @@ from gems.study import (
     PortRef,
     System,
     create_component,
-)
+    Study,)
 
 
 def test_quota_co2() -> None:
@@ -83,7 +83,7 @@ def test_quota_co2() -> None:
     database.add_data("QuotaCO2", "quota", ConstantData(150))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
 
     assert problem.termination_condition == "optimal"

--- a/tests/e2e/models/poc-various-models/test_quota_co2_yaml.py
+++ b/tests/e2e/models/poc-various-models/test_quota_co2_yaml.py
@@ -26,7 +26,7 @@ from gems.study import (
     PortRef,
     System,
     create_component,
-)
+    Study,)
 
 
 def test_quota_co2(
@@ -89,7 +89,7 @@ def test_quota_co2(
     database.add_data("QuotaCO2", "quota", ConstantData(150))
 
     scenarios = 1
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios)
     problem.solve(solver_name="highs")
 
     assert problem.termination_condition == "optimal"

--- a/tests/e2e/models/poc-various-models/test_quota_co2_yaml.py
+++ b/tests/e2e/models/poc-various-models/test_quota_co2_yaml.py
@@ -24,9 +24,10 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     create_component,
-    Study,)
+)
 
 
 def test_quota_co2(

--- a/tests/e2e/models/poc-various-models/test_short_term_storage_complex.py
+++ b/tests/e2e/models/poc-various-models/test_short_term_storage_complex.py
@@ -15,10 +15,11 @@ from gems.study import (
     ConstantData,
     DataBase,
     PortRef,
+    Study,
     System,
     TimeScenarioSeriesData,
     create_component,
-    Study,)
+)
 
 
 def generate_data(

--- a/tests/e2e/models/poc-various-models/test_short_term_storage_complex.py
+++ b/tests/e2e/models/poc-various-models/test_short_term_storage_complex.py
@@ -18,7 +18,7 @@ from gems.study import (
     System,
     TimeScenarioSeriesData,
     create_component,
-)
+    Study,)
 
 
 def generate_data(
@@ -90,8 +90,7 @@ def short_term_storage_base(efficiency: float, horizon: int, result: int) -> Non
     system.connect(PortRef(unsupplied, "balance_port"), PortRef(node, "balance_port"))
 
     problem = build_problem(
-        system,
-        database,
+        Study(system, database),
         time_blocks[0],
         scenarios,
         border_management=BlockBorderManagement.CYCLE,

--- a/tests/e2e/studies/test_studies.py
+++ b/tests/e2e/studies/test_studies.py
@@ -31,9 +31,10 @@ from pathlib import Path
 
 import pytest
 
-from gems.main.main import _write_structure_txt, input_database, input_libs, input_study
+from gems.main.main import _write_structure_txt, input_database, input_libs, input_system
 from gems.optim_config.parsing import load_optim_config, validate_optim_config
 from gems.simulation import TimeBlock, build_decomposed_problems
+from gems.study import Study
 
 STUDIES_DIR = Path(__file__).parent
 STUDY_IDS = ["13_1", "13_2"]
@@ -51,7 +52,7 @@ def test_study_mps_matches_expected(study_id: str, tmp_path: Path) -> None:
 
     # --- Load system and database ---
     system_path = input_dir / "system.yml"
-    system = input_study(system_path, lib_dict)
+    system = input_system(system_path, lib_dict)
     database = input_database(system_path, timeseries_path=None)
 
     # --- Load and validate optim-config ---
@@ -64,7 +65,7 @@ def test_study_mps_matches_expected(study_id: str, tmp_path: Path) -> None:
     time_block = TimeBlock(1, [0])
     scenarios = 1
     decomposed = build_decomposed_problems(
-        system, database, time_block, scenarios, optim_config
+        Study(system, database), time_block, scenarios, optim_config
     )
 
     # --- Write MPS files ---

--- a/tests/e2e/studies/test_studies.py
+++ b/tests/e2e/studies/test_studies.py
@@ -31,7 +31,12 @@ from pathlib import Path
 
 import pytest
 
-from gems.main.main import _write_structure_txt, input_database, input_libs, input_system
+from gems.main.main import (
+    _write_structure_txt,
+    input_database,
+    input_libs,
+    input_system,
+)
 from gems.optim_config.parsing import load_optim_config, validate_optim_config
 from gems.simulation import TimeBlock, build_decomposed_problems
 from gems.study import Study

--- a/tests/unittests/simulation/test_simulation_table_extra_outputs.py
+++ b/tests/unittests/simulation/test_simulation_table_extra_outputs.py
@@ -22,7 +22,7 @@ def test_extra_output_with_sum_connections() -> None:
     from gems.model.port import PortField, PortFieldDefinition, PortFieldId, PortType
     from gems.model.variable import float_variable
     from gems.simulation import TimeBlock, build_problem
-    from gems.study import Component, DataBase, PortRef, System, create_component
+    from gems.study import Component, DataBase, PortRef, Study, System, create_component
 
     BALANCE_PORT_TYPE = PortType(id="balance", fields=[PortField("flow")])
 
@@ -62,7 +62,7 @@ def test_extra_output_with_sum_connections() -> None:
         PortRef(gen_comp, "balance_port"), PortRef(node_comp, "balance_port")
     )
 
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios=1)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios=1)
     problem.solve(solver_name="highs")
 
     df = SimulationTableBuilder().build(problem)
@@ -90,7 +90,7 @@ def test_extra_output_nonlinear() -> None:
     from gems.model.model import model
     from gems.model.variable import float_variable
     from gems.simulation import TimeBlock, build_problem
-    from gems.study import DataBase, System, create_component
+    from gems.study import DataBase, Study, System, create_component
 
     SIMPLE_MODEL = model(
         id="SIMPLE_NL",
@@ -104,7 +104,7 @@ def test_extra_output_nonlinear() -> None:
     system = System("test_nonlinear")
     system.add_component(comp)
 
-    problem = build_problem(system, database, TimeBlock(1, [0]), scenarios=1)
+    problem = build_problem(Study(system, database), TimeBlock(1, [0]), scenarios=1)
     problem.solve(solver_name="highs")
 
     df = SimulationTableBuilder().build(problem)

--- a/tests/unittests/system/test_data_consistency.py
+++ b/tests/unittests/system/test_data_consistency.py
@@ -38,7 +38,7 @@ from gems.study import (
     TimeScenarioSeriesData,
     TimeSeriesData,
     create_component,
-)
+    Study,)
 from gems.study.data import load_ts_from_file
 from tests.unittests.system.libs.standard import (
     BALANCE_PORT_TYPE,
@@ -151,7 +151,7 @@ def test_requirements_consistency_demand_model_fix_ok(
 
     # When
     # No ValueError should be raised
-    database.requirements_consistency(mock_network)
+    Study(mock_network, database).check_consistency()
 
 
 def test_requirements_consistency_generator_model_ok(mock_network: System) -> None:
@@ -164,7 +164,7 @@ def test_requirements_consistency_generator_model_ok(mock_network: System) -> No
     database.add_data("D", "demand", ConstantData(30))
 
     # When
-    database.requirements_consistency(mock_network)
+    Study(mock_network, database).check_consistency()
 
 
 def test_consistency_generation_time_free_for_constant_model_raises_exception(
@@ -183,7 +183,7 @@ def test_consistency_generation_time_free_for_constant_model_raises_exception(
 
     # When
     with pytest.raises(ValueError, match="Data inconsistency"):
-        database.requirements_consistency(mock_network)
+        Study(mock_network, database).check_consistency()
 
 
 def test_requirements_consistency_demand_model_time_varying_ok(
@@ -199,7 +199,7 @@ def test_requirements_consistency_demand_model_time_varying_ok(
 
     # When
     # No ValueError should be raised
-    database.requirements_consistency(mock_network)
+    Study(mock_network, database).check_consistency()
 
 
 def test_requirements_consistency_time_varying_parameter_with_correct_data_passes(
@@ -224,7 +224,7 @@ def test_requirements_consistency_time_varying_parameter_with_correct_data_passe
     system.connect(PortRef(gen, "balance_port"), PortRef(node, "balance_port"))
 
     # No ValueError should be raised
-    database.requirements_consistency(system)
+    Study(system, database).check_consistency()
 
 
 @pytest.mark.parametrize(
@@ -269,7 +269,7 @@ def test_requirements_consistency_time_varying_parameter_with_scenario_varying_d
     # When
     # ValueError should be raised
     with pytest.raises(ValueError, match="Data inconsistency"):
-        database.requirements_consistency(system)
+        Study(system, database).check_consistency()
 
 
 @pytest.mark.parametrize(
@@ -305,7 +305,7 @@ def test_requirements_consistency_scenario_varying_parameter_with_time_varying_d
 
     # ValueError should be raised
     with pytest.raises(ValueError, match="Data inconsistency"):
-        database.requirements_consistency(system)
+        Study(system, database).check_consistency()
 
 
 def test_requirements_consistency_scenario_varying_parameter_with_correct_data_passes(
@@ -330,7 +330,7 @@ def test_requirements_consistency_scenario_varying_parameter_with_correct_data_p
     system.add_component(gen)
 
     # No ValueError should be raised
-    database.requirements_consistency(system)
+    Study(system, database).check_consistency()
 
 
 def test_load_data_from_txt() -> None:

--- a/tests/unittests/system/test_data_consistency.py
+++ b/tests/unittests/system/test_data_consistency.py
@@ -33,12 +33,13 @@ from gems.study import (
     PortRef,
     ScenarioIndex,
     ScenarioSeriesData,
+    Study,
     System,
     TimeIndex,
     TimeScenarioSeriesData,
     TimeSeriesData,
     create_component,
-    Study,)
+)
 from gems.study.data import load_ts_from_file
 from tests.unittests.system.libs.standard import (
     BALANCE_PORT_TYPE,


### PR DESCRIPTION
Closes #78 

`System` (component topology) and `DataBase` (parameter values) were always passed together as a pair throughout the codebase.  This commit introduces a `Study` dataclass that holds both as attributes and centralises the cross-validation logic previously scattered across `DataBase.requirements_consistency` and its call sites.

Changes:
- Add `gems.study.study.Study` dataclass with `check_consistency()` method
- Remove `DataBase.requirements_consistency(system)` (logic moved to `Study`)
- Update `build_problem()` and `build_decomposed_problems()` to accept `Study`
- Update `load_study()` to return `Study` instead of `tuple[System, DataBase]`
- Rename `input_study()` → `input_system()` in `main.py` to avoid name clash
- Update all call sites in tests (61 build_problem, 2 build_decomposed_problems, 8 requirements_consistency, 1 load_study unpack) and documentation

https://claude.ai/code/session_01Wmj8XYdCk1EPKCeGs7dHAq