### PR TITLE
Tolerate absence of expec() in objective contributions (Issue #76)

### DIFF
--- a/src/gems/model/model.py
+++ b/src/gems/model/model.py
@@ -32,13 +32,16 @@ from gems.model.variable import Variable
 
 
 # TODO: Introduce bool_variable ?
-def _make_structure_provider(model: "Model") -> IndexingStructureProvider:
+def _make_structure_provider(
+    parameters: Dict[str, Parameter],
+    variables: Dict[str, Variable],
+) -> IndexingStructureProvider:
     class Provider(IndexingStructureProvider):
         def get_parameter_structure(self, name: str) -> IndexingStructure:
-            return model.parameters[name].structure
+            return parameters[name].structure
 
         def get_variable_structure(self, name: str) -> IndexingStructure:
-            return model.variables[name].structure
+            return variables[name].structure
 
     return Provider()
 
@@ -66,14 +69,7 @@ def _normalize_objective_contributions(
     should be removed and authors should be required to write expec() explicitly.
     """
 
-    class _Provider(IndexingStructureProvider):
-        def get_parameter_structure(self, name: str) -> IndexingStructure:
-            return parameters[name].structure
-
-        def get_variable_structure(self, name: str) -> IndexingStructure:
-            return variables[name].structure
-
-    provider = _Provider()
+    provider = _make_structure_provider(parameters, variables)
     result: Dict[str, ExpressionNode] = {}
     for contrib_id, expr in contributions.items():
         structure = compute_indexation(expr, provider)
@@ -97,7 +93,9 @@ def _is_objective_contribution_valid(
     if not is_linear(objective_contribution):
         raise ValueError("Objective contribution must be a linear expression.")
 
-    data_structure_provider = _make_structure_provider(model)
+    data_structure_provider = _make_structure_provider(
+        model.parameters, model.variables
+    )
     objective_structure = compute_indexation(
         objective_contribution, data_structure_provider
     )

--- a/src/gems/model/model.py
+++ b/src/gems/model/model.py
@@ -60,6 +60,10 @@ def _normalize_objective_contributions(
     are returned unchanged with no warning.
 
     This implements the iso-format behaviour of Antares Simulator v10.0.0 (Issue #76).
+
+    TODO: This auto-wrapping is a temporary compatibility shim. Once Antares Simulator
+    natively supports the expec() operator in objective contributions, this function
+    should be removed and authors should be required to write expec() explicitly.
     """
 
     class _Provider(IndexingStructureProvider):

--- a/src/gems/model/model.py
+++ b/src/gems/model/model.py
@@ -17,6 +17,7 @@ defining parameters, variables, and equations.
 """
 
 import itertools
+import warnings
 from dataclasses import dataclass, field, replace
 from typing import Any, Dict, Iterable, Optional
 
@@ -40,6 +41,50 @@ def _make_structure_provider(model: "Model") -> IndexingStructureProvider:
             return model.variables[name].structure
 
     return Provider()
+
+
+def _normalize_objective_contributions(
+    contributions: Dict[str, ExpressionNode],
+    parameters: Dict[str, Parameter],
+    variables: Dict[str, Variable],
+) -> Dict[str, ExpressionNode]:
+    """
+    Tolerate absence of expec() in objective contributions that carry a residual
+    scenario dimension (IndexingStructure(time=False, scenario=True)).
+
+    Such contributions are automatically wrapped with expec(), applying
+    expectation (average-over-scenarios) semantics, and a UserWarning is emitted
+    so authors can add expec() explicitly at their convenience.
+
+    Contributions that are already fully scalar, or already wrapped in expec(),
+    are returned unchanged with no warning.
+
+    This implements the iso-format behaviour of Antares Simulator v10.0.0 (Issue #76).
+    """
+
+    class _Provider(IndexingStructureProvider):
+        def get_parameter_structure(self, name: str) -> IndexingStructure:
+            return parameters[name].structure
+
+        def get_variable_structure(self, name: str) -> IndexingStructure:
+            return variables[name].structure
+
+    provider = _Provider()
+    result: Dict[str, ExpressionNode] = {}
+    for contrib_id, expr in contributions.items():
+        structure = compute_indexation(expr, provider)
+        if structure == IndexingStructure(time=False, scenario=True):
+            warnings.warn(
+                f"Objective contribution '{contrib_id}' has a scenario dimension "
+                "but no explicit expec() operator. "
+                "Expectation semantics (average over scenarios) are applied "
+                "automatically. Add expec() explicitly to suppress this warning.",
+                UserWarning,
+                stacklevel=4,
+            )
+            expr = expr.expec()
+        result[contrib_id] = expr
+    return result
 
 
 def _is_objective_contribution_valid(
@@ -140,6 +185,17 @@ def model(
     """
     Utility method to create Models from relaxed arguments
     """
+    # Build dicts upfront so we can inspect indexing structure before Model construction.
+    params_dict = {p.name: p for p in parameters} if parameters else {}
+    vars_dict = {v.name: v for v in variables} if variables else {}
+
+    # Auto-wrap any objective contribution that has a residual scenario dimension
+    # without an explicit expec() (Issue #76 / Antares Simulator v10.0.0 iso-format).
+    if objective_contributions:
+        objective_contributions = _normalize_objective_contributions(
+            objective_contributions, params_dict, vars_dict
+        )
+
     existing_port_names = {}
     if ports:
         for port in ports:
@@ -156,8 +212,8 @@ def model(
         binding_constraints=(
             {c.name: c for c in binding_constraints} if binding_constraints else {}
         ),
-        parameters={p.name: p for p in parameters} if parameters else {},
-        variables={v.name: v for v in variables} if variables else {},
+        parameters=params_dict,
+        variables=vars_dict,
         objective_contributions=objective_contributions,
         inter_block_dyn=inter_block_dyn,
         ports=existing_port_names,

--- a/tests/unittests/system/test_model.py
+++ b/tests/unittests/system/test_model.py
@@ -10,9 +10,19 @@
 #
 # This file is part of the Antares project.
 
+import warnings
+
 import pytest
 
-from gems.expression.expression import ExpressionNode, literal, param, port_field, var
+from gems.expression.expression import (
+    ExpressionNode,
+    ScenarioOperatorNode,
+    literal,
+    param,
+    port_field,
+    var,
+)
+from gems.expression.indexing_structure import IndexingStructure
 from gems.model import Constraint, float_variable, model
 from gems.model.port import port_field_def
 
@@ -205,3 +215,88 @@ def test_constraint_equals() -> None:
     assert Constraint(name="c", expression=var("x") <= param("p")) != Constraint(
         name="c", expression=var("y") <= param("p")
     )
+
+
+# --- Issue #76: tolerate absence of expec() in objective contributions ---
+
+
+def test_objective_without_expec_on_scenario_var_emits_warning_and_wraps() -> None:
+    """
+    When a scenario-dependent variable is used in an objective contribution
+    without expec(), the model() factory should auto-wrap with expec() and
+    emit a UserWarning.
+    """
+    scenario_var = float_variable("generation", structure=IndexingStructure(True, True))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        m = model(
+            id="auto_wrap_model",
+            variables=[scenario_var],
+            objective_contributions={"operational": var("generation").time_sum()},
+        )
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1
+    assert "expec()" in str(user_warnings[0].message)
+    assert "operational" in str(user_warnings[0].message)
+    # The stored expression must now be wrapped in expec()
+    stored = m.objective_contributions["operational"]
+    assert isinstance(stored, ScenarioOperatorNode)
+    assert stored.name == "Expectation"
+
+
+def test_objective_with_explicit_expec_emits_no_warning() -> None:
+    """
+    When expec() is already present in the objective contribution,
+    no warning should be emitted and the expression is not double-wrapped.
+    """
+    scenario_var = float_variable("generation", structure=IndexingStructure(True, True))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        m = model(
+            id="explicit_expec_model",
+            variables=[scenario_var],
+            objective_contributions={
+                "operational": var("generation").time_sum().expec()
+            },
+        )
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 0
+    stored = m.objective_contributions["operational"]
+    assert isinstance(stored, ScenarioOperatorNode)
+    assert stored.name == "Expectation"
+    # Must not be double-wrapped
+    assert not isinstance(stored.operand, ScenarioOperatorNode)
+
+
+def test_objective_with_non_scenario_var_emits_no_warning() -> None:
+    """
+    When the objective contribution is already a scalar (no scenario dimension),
+    no auto-wrapping or warning should occur.
+    """
+    non_scenario_var = float_variable(
+        "generation", structure=IndexingStructure(True, False)
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        model(
+            id="non_scenario_model",
+            variables=[non_scenario_var],
+            objective_contributions={"operational": var("generation").time_sum()},
+        )
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 0
+
+
+def test_objective_with_time_dimension_remaining_is_still_rejected() -> None:
+    """
+    Auto-wrapping only applies when scenario=True and time=False.
+    If time dimension is still present (missing time_sum()), validation must fail.
+    """
+    scenario_var = float_variable("generation", structure=IndexingStructure(True, True))
+    with pytest.raises(ValueError, match="real-valued expression"):
+        model(
+            id="bad_time_model",
+            variables=[scenario_var],
+            # No time_sum() — still has time dimension → rejected regardless
+            objective_contributions={"operational": var("generation")},
+        )


### PR DESCRIPTION
When an objective contribution has a residual scenario dimension but no explicit expec() operator, the model() factory now automatically wraps the expression with expec() (average-over-scenarios semantics) and emits a UserWarning pointing authors to add the explicit form.

Expressions that are already fully scalar, or already wrapped in expec(), are left unchanged with no warning. Time dimension errors are still rejected.

This achieves iso-format with Antares Simulator v10.0.0.

Closes #76 

https://claude.ai/code/session_01SDhHG2UhKm1wjvhDKxKXLu