### PR TITLE
fix: add FakeStudy to test stubs so FakeProblem exposes problem.study

### DIFF
--- a/tests/unittests/simulation/test_simulation_table_accessor.py
+++ b/tests/unittests/simulation/test_simulation_table_accessor.py
@@ -40,6 +40,12 @@ class FakeModel:
 
 
 @dataclass
+class FakeStudy:
+    model_components: dict = field(default_factory=dict)
+    models: dict = field(default_factory=dict)
+
+
+@dataclass
 class FakeLinopyModel:
     solution: dict
 
@@ -53,6 +59,7 @@ class FakeProblem:
     _linopy_vars: dict = field(default_factory=dict)
     models: dict = field(default_factory=dict)
     model_components: dict = field(default_factory=dict)
+    study: FakeStudy = field(default_factory=FakeStudy)
     scenarios: int = 1
 
 
@@ -78,6 +85,7 @@ def _make_single_scenario_problem() -> FakeProblem:
         _linopy_vars={(0, "p"): fake_var},
         models={0: FakeModel()},
         model_components={},
+        study=FakeStudy(models={0: FakeModel()}, model_components={}),
         scenarios=1,
     )
 
@@ -100,6 +108,7 @@ def _make_multi_scenario_problem() -> FakeProblem:
         _linopy_vars={(0, "p"): fake_var},
         models={0: FakeModel()},
         model_components={},
+        study=FakeStudy(models={0: FakeModel()}, model_components={}),
         scenarios=2,
     )
 
@@ -246,6 +255,7 @@ def _make_scenario_independent_problem() -> FakeProblem:
         _linopy_vars={(0, "p"): fake_var},
         models={0: FakeModel()},
         model_components={},
+        study=FakeStudy(models={0: FakeModel()}, model_components={}),
         scenarios=1,
     )
 
@@ -267,6 +277,7 @@ def _make_scalar_output_problem() -> FakeProblem:
         _linopy_vars={(0, "p"): fake_var},
         models={0: FakeModel()},
         model_components={},
+        study=FakeStudy(models={0: FakeModel()}, model_components={}),
         scenarios=1,
     )
 

--- a/tests/unittests/simulation/test_simulation_table_export.py
+++ b/tests/unittests/simulation/test_simulation_table_export.py
@@ -41,6 +41,12 @@ class FakeModel:
 
 
 @dataclass
+class FakeStudy:
+    model_components: dict = field(default_factory=dict)
+    models: dict = field(default_factory=dict)
+
+
+@dataclass
 class FakeLinopyModel:
     solution: dict
 
@@ -54,6 +60,7 @@ class FakeProblem:
     _linopy_vars: dict = field(default_factory=dict)
     models: dict = field(default_factory=dict)
     model_components: dict = field(default_factory=dict)
+    study: FakeStudy = field(default_factory=FakeStudy)
     scenarios: int = 1
 
 
@@ -78,6 +85,7 @@ def _make_problem(n_scenarios: int = 1) -> FakeProblem:
         _linopy_vars={(0, "p"): fake_var},
         models={0: FakeModel()},
         model_components={},
+        study=FakeStudy(models={0: FakeModel()}, model_components={}),
         scenarios=n_scenarios,
     )
 

--- a/tests/unittests/simulation/test_simulation_table_mock.py
+++ b/tests/unittests/simulation/test_simulation_table_mock.py
@@ -40,6 +40,12 @@ class FakeModel:
 
 
 @dataclass
+class FakeStudy:
+    model_components: dict = field(default_factory=dict)
+    models: dict = field(default_factory=dict)
+
+
+@dataclass
 class FakeLinopyModel:
     """Fake linopy model exposing a solution dataset."""
 
@@ -57,6 +63,7 @@ class FakeProblem:
     _linopy_vars: dict = field(default_factory=dict)
     models: dict = field(default_factory=dict)
     model_components: dict = field(default_factory=dict)
+    study: FakeStudy = field(default_factory=FakeStudy)
 
 
 def test_simulation_table_builder_manual(tmp_path: Path) -> None:
@@ -77,6 +84,7 @@ def test_simulation_table_builder_manual(tmp_path: Path) -> None:
         _linopy_vars={(0, "p"): fake_var},
         models={0: FakeModel()},
         model_components={},
+        study=FakeStudy(models={0: FakeModel()}, model_components={}),
     )
 
     builder = SimulationTableBuilder(simulation_id="test")
@@ -164,6 +172,7 @@ def _make_problem_with_da(da: xr.DataArray, var_name: str = "p") -> "FakeProblem
         _linopy_vars={(0, var_name): fake_var},
         models={0: FakeModel()},
         model_components={},
+        study=FakeStudy(models={0: FakeModel()}, model_components={}),
     )
 
 


### PR DESCRIPTION
simulation_table.py now accesses problem.study.model_components and problem.study.models, but the FakeProblem stubs in three test files only exposed those as direct attributes. Add FakeStudy dataclass and a study field to FakeProblem in each test file, then pass it from every factory/inline constructor.

https://claude.ai/code/session_013e7p8jzM9WY74X7aYJqByK