### PR TITLE
refactor: rename Input[X] Pydantic classes to [X]Schema (issue #75)

### DIFF
--- a/src/gems/model/parsing.py
+++ b/src/gems/model/parsing.py
@@ -19,21 +19,21 @@ from yaml import safe_load
 from gems.utils import ModifiedBaseModel
 
 
-def parse_yaml_library(input: typing.TextIO) -> "InputLibrary":
+def parse_yaml_library(input: typing.TextIO) -> "LibrarySchema":
     tree = safe_load(input)
     try:
-        return InputLibrary.model_validate(tree["library"])
+        return LibrarySchema.model_validate(tree["library"])
     except ValidationError as e:
         raise ValueError(f"An error occurred during parsing: {e}")
 
 
-class InputParameter(ModifiedBaseModel):
+class ParameterSchema(ModifiedBaseModel):
     id: str
     time_dependent: bool = False
     scenario_dependent: bool = False
 
 
-class InputVariable(ModifiedBaseModel):
+class VariableSchema(ModifiedBaseModel):
     id: str
     time_dependent: bool = True
     scenario_dependent: bool = True
@@ -46,63 +46,63 @@ class InputVariable(ModifiedBaseModel):
     )
 
 
-class InputConstraint(ModifiedBaseModel):
+class ConstraintSchema(ModifiedBaseModel):
     id: str
     expression: str
     lower_bound: Optional[str] = None
     upper_bound: Optional[str] = None
 
 
-class InputField(ModifiedBaseModel):
+class FieldSchema(ModifiedBaseModel):
     id: str
 
 
-class InputPortType(ModifiedBaseModel):
+class PortTypeSchema(ModifiedBaseModel):
     id: str
-    fields: List[InputField] = Field(default_factory=list)
+    fields: List[FieldSchema] = Field(default_factory=list)
     description: Optional[str] = None
 
 
-class InputModelPort(ModifiedBaseModel):
+class ModelPortSchema(ModifiedBaseModel):
     id: str
     type: str
 
 
-class InputPortFieldDefinition(ModifiedBaseModel):
+class PortFieldDefinitionSchema(ModifiedBaseModel):
     port: str
     field: str
     definition: str
 
 
-class InputObjectiveContribution(ModifiedBaseModel):
+class ObjectiveContributionSchema(ModifiedBaseModel):
     id: str
     expression: str
 
 
 @dataclass
-class InputExtraOutput(ModifiedBaseModel):
+class ExtraOutputSchema(ModifiedBaseModel):
     id: str
     expression: str
 
 
-class InputModel(ModifiedBaseModel):
+class ModelSchema(ModifiedBaseModel):
     id: str
-    parameters: List[InputParameter] = Field(default_factory=list)
-    variables: List[InputVariable] = Field(default_factory=list)
-    ports: List[InputModelPort] = Field(default_factory=list)
-    port_field_definitions: List[InputPortFieldDefinition] = Field(default_factory=list)
-    binding_constraints: List[InputConstraint] = Field(default_factory=list)
-    constraints: List[InputConstraint] = Field(default_factory=list)
-    objective_contributions: List[InputObjectiveContribution] = Field(
+    parameters: List[ParameterSchema] = Field(default_factory=list)
+    variables: List[VariableSchema] = Field(default_factory=list)
+    ports: List[ModelPortSchema] = Field(default_factory=list)
+    port_field_definitions: List[PortFieldDefinitionSchema] = Field(default_factory=list)
+    binding_constraints: List[ConstraintSchema] = Field(default_factory=list)
+    constraints: List[ConstraintSchema] = Field(default_factory=list)
+    objective_contributions: List[ObjectiveContributionSchema] = Field(
         default_factory=list, alias="objective-contributions"
     )
     description: Optional[str] = None
-    extra_outputs: Optional[List[InputExtraOutput]] = None
+    extra_outputs: Optional[List[ExtraOutputSchema]] = None
 
 
-class InputLibrary(ModifiedBaseModel):
+class LibrarySchema(ModifiedBaseModel):
     id: str
     dependencies: List[str] = Field(default_factory=list)
-    port_types: List[InputPortType] = Field(default_factory=list)
-    models: List[InputModel] = Field(default_factory=list)
+    port_types: List[PortTypeSchema] = Field(default_factory=list)
+    models: List[ModelSchema] = Field(default_factory=list)
     description: Optional[str] = None

--- a/src/gems/model/parsing.py
+++ b/src/gems/model/parsing.py
@@ -90,7 +90,9 @@ class ModelSchema(ModifiedBaseModel):
     parameters: List[ParameterSchema] = Field(default_factory=list)
     variables: List[VariableSchema] = Field(default_factory=list)
     ports: List[ModelPortSchema] = Field(default_factory=list)
-    port_field_definitions: List[PortFieldDefinitionSchema] = Field(default_factory=list)
+    port_field_definitions: List[PortFieldDefinitionSchema] = Field(
+        default_factory=list
+    )
     binding_constraints: List[ConstraintSchema] = Field(default_factory=list)
     constraints: List[ConstraintSchema] = Field(default_factory=list)
     objective_contributions: List[ObjectiveContributionSchema] = Field(

--- a/src/gems/model/resolve_library.py
+++ b/src/gems/model/resolve_library.py
@@ -28,21 +28,21 @@ from gems.model import (
 from gems.model.library import Library
 from gems.model.model import model
 from gems.model.parsing import (
-    InputConstraint,
-    InputField,
-    InputLibrary,
-    InputModel,
-    InputModelPort,
-    InputParameter,
-    InputPortFieldDefinition,
-    InputPortType,
-    InputVariable,
+    ConstraintSchema,
+    FieldSchema,
+    LibrarySchema,
+    ModelSchema,
+    ModelPortSchema,
+    ParameterSchema,
+    PortFieldDefinitionSchema,
+    PortTypeSchema,
+    VariableSchema,
 )
 from gems.model.port import PortFieldDefinition, port_field_def
 
 
 def resolve_library(
-    input_libs: List[InputLibrary], preloaded_libs: Optional[List[Library]] = None
+    input_libs: List[LibrarySchema], preloaded_libs: Optional[List[Library]] = None
 ) -> Dict[str, Library]:
     """
     Converts parsed data into an actually usable library of models.
@@ -104,7 +104,7 @@ def _add_preloaded_port_types_to_current_lib(
 def _add_resolved_dependent_port_types_to_current_lib(
     output_lib_dict: Dict[str, Library],
     treated_lib_ids: Set[str],
-    cur_yaml_lib: InputLibrary,
+    cur_yaml_lib: LibrarySchema,
     current_lib: Library,
 ) -> None:
     done_dependencies = set(cur_yaml_lib.dependencies) & treated_lib_ids
@@ -119,7 +119,7 @@ def _update_treated_libs_and_import_stack(
 
 
 def _resolve_lib(
-    current_lib: Library, cur_yaml_lib: InputLibrary, output_lib: Dict[str, Library]
+    current_lib: Library, cur_yaml_lib: LibrarySchema, output_lib: Dict[str, Library]
 ) -> None:
     port_types = [_convert_port_type(p) for p in cur_yaml_lib.port_types]
     port_types_dict = dict((p.id, p) for p in port_types)
@@ -156,18 +156,18 @@ def _add_dependencies_to_stack(
     import_stack.append(first_dependency)
 
 
-def _convert_field(field: InputField) -> PortField:
+def _convert_field(field: FieldSchema) -> PortField:
     return PortField(name=field.id)
 
 
-def _convert_port_type(port_type: InputPortType) -> PortType:
+def _convert_port_type(port_type: PortTypeSchema) -> PortType:
     return PortType(
         id=port_type.id, fields=[_convert_field(f) for f in port_type.fields]
     )
 
 
 def _resolve_model(
-    input_model: InputModel, port_types: Dict[str, PortType], library_id: str
+    input_model: ModelSchema, port_types: Dict[str, PortType], library_id: str
 ) -> Model:
     identifiers = ModelIdentifiers(
         variables={v.id for v in input_model.variables},
@@ -208,13 +208,13 @@ def _resolve_model(
 
 
 def _resolve_model_port(
-    port: InputModelPort, port_types: Dict[str, PortType]
+    port: ModelPortSchema, port_types: Dict[str, PortType]
 ) -> ModelPort:
     return ModelPort(port_name=port.id, port_type=port_types[port.type])
 
 
 def _resolve_field_definition(
-    definition: InputPortFieldDefinition, ids: ModelIdentifiers
+    definition: PortFieldDefinitionSchema, ids: ModelIdentifiers
 ) -> PortFieldDefinition:
     return port_field_def(
         port_name=definition.port,
@@ -223,7 +223,7 @@ def _resolve_field_definition(
     )
 
 
-def _to_parameter(param: InputParameter) -> Parameter:
+def _to_parameter(param: ParameterSchema) -> Parameter:
     return Parameter(
         name=param.id,
         type=ValueType.CONTINUOUS,
@@ -239,7 +239,7 @@ def _to_expression_if_present(
     return parse_expression(expr, identifiers)
 
 
-def _to_variable(var: InputVariable, identifiers: ModelIdentifiers) -> Variable:
+def _to_variable(var: VariableSchema, identifiers: ModelIdentifiers) -> Variable:
     return Variable(
         name=var.id,
         data_type={"continuous": ValueType.CONTINUOUS, "integer": ValueType.INTEGER}[
@@ -252,7 +252,7 @@ def _to_variable(var: InputVariable, identifiers: ModelIdentifiers) -> Variable:
 
 
 def _to_constraint(
-    constraint: InputConstraint, identifiers: ModelIdentifiers
+    constraint: ConstraintSchema, identifiers: ModelIdentifiers
 ) -> Constraint:
     lb = _to_expression_if_present(constraint.lower_bound, identifiers)
     ub = _to_expression_if_present(constraint.upper_bound, identifiers)

--- a/src/gems/study/parsing.py
+++ b/src/gems/study/parsing.py
@@ -23,17 +23,17 @@ from yaml import safe_load
 from gems.utils import ModifiedBaseModel
 
 
-def load_input_system(input_study: Path) -> "InputSystem":
+def load_input_system(input_study: Path) -> "SystemSchema":
     try:
         with input_study.open() as f:
-            return InputSystem.model_validate(safe_load(f))
+            return SystemSchema.model_validate(safe_load(f))
     except ValidationError as e:
         raise ValueError(f"An error occurred during parsing: {e}")
 
 
-def parse_yaml_components(input_study: TextIO) -> "InputSystem":
+def parse_yaml_components(input_study: TextIO) -> "SystemSchema":
     tree = safe_load(input_study)
-    return InputSystem.model_validate(tree["system"])
+    return SystemSchema.model_validate(tree["system"])
 
 
 def parse_scenario_builder(file: Path) -> pd.DataFrame:
@@ -42,20 +42,20 @@ def parse_scenario_builder(file: Path) -> pd.DataFrame:
     return sb
 
 
-class InputAreaConnections(ModifiedBaseModel):
+class AreaConnectionsSchema(ModifiedBaseModel):
     component: str
     port: str
     area: str
 
 
-class InputPortConnections(ModifiedBaseModel):
+class PortConnectionsSchema(ModifiedBaseModel):
     component1: str
     port1: str
     component2: str
     port2: str
 
 
-class InputComponentParameter(ModifiedBaseModel):
+class ComponentParameterSchema(ModifiedBaseModel):
     id: str
     time_dependent: bool = False
     scenario_dependent: bool = False
@@ -63,19 +63,19 @@ class InputComponentParameter(ModifiedBaseModel):
     scenario_group: Optional[str] = None
 
 
-class InputComponent(ModifiedBaseModel):
+class ComponentSchema(ModifiedBaseModel):
     id: str
     model: str
     scenario_group: Optional[str] = None
-    parameters: Optional[List[InputComponentParameter]] = None
+    parameters: Optional[List[ComponentParameterSchema]] = None
 
 
-class InputSystem(ModifiedBaseModel):
+class SystemSchema(ModifiedBaseModel):
     id: Optional[str] = None
     model_libraries: Optional[str] = None  # Parsed but unused for now
-    components: List[InputComponent] = Field(default_factory=list)
-    connections: Optional[List[InputPortConnections]] = None
-    area_connections: Optional[List[InputAreaConnections]] = None
+    components: List[ComponentSchema] = Field(default_factory=list)
+    connections: Optional[List[PortConnectionsSchema]] = None
+    area_connections: Optional[List[AreaConnectionsSchema]] = None
 
 
 @dataclass(frozen=True)

--- a/src/gems/study/resolve_components.py
+++ b/src/gems/study/resolve_components.py
@@ -34,10 +34,10 @@ from gems.study.data import (
     dataframe_to_time_series,
     load_ts_from_file,
 )
-from gems.study.parsing import InputComponent, InputPortConnections, InputSystem
+from gems.study.parsing import ComponentSchema, PortConnectionsSchema, SystemSchema
 
 
-def resolve_system(input_system: InputSystem, libraries: dict[str, Library]) -> System:
+def resolve_system(input_system: SystemSchema, libraries: dict[str, Library]) -> System:
     """
     Resolves:
     - components to be used for study
@@ -59,7 +59,7 @@ def resolve_system(input_system: InputSystem, libraries: dict[str, Library]) -> 
 
 
 def _resolve_component(
-    libraries: dict[str, Library], component: InputComponent
+    libraries: dict[str, Library], component: ComponentSchema
 ) -> Component:
     lib_id, model_id = component.model.split(".")
     model = libraries[lib_id].models[f"{lib_id}.{model_id}"]
@@ -71,7 +71,7 @@ def _resolve_component(
 
 
 def _resolve_port_refs(
-    connection: InputPortConnections,
+    connection: PortConnectionsSchema,
     all_components: List[Component],
 ) -> Tuple[PortRef, PortRef]:
     component_1 = _get_component_by_id(all_components, connection.component1)
@@ -105,7 +105,7 @@ def consistency_check(system: System, input_models: Dict[str, Model]) -> bool:
 
 
 def build_data_base(
-    input_system: InputSystem, timeseries_dir: Optional[Path]
+    input_system: SystemSchema, timeseries_dir: Optional[Path]
 ) -> DataBase:
     database = DataBase()
     for comp in input_system.components:
@@ -165,7 +165,7 @@ def _resolve_scenarization(
 
 
 def build_scenarized_data_base(
-    input_comp: InputSystem,
+    input_comp: SystemSchema,
     scenario_builder_data: pd.DataFrame,
     timeseries_dir: Optional[Path],
 ) -> DataBase:

--- a/tests/e2e/functional/conftest.py
+++ b/tests/e2e/functional/conftest.py
@@ -13,9 +13,9 @@ from pathlib import Path
 
 import pytest
 
-from gems.model.parsing import InputLibrary, parse_yaml_library
+from gems.model.parsing import LibrarySchema, parse_yaml_library
 from gems.model.resolve_library import Library, resolve_library
-from gems.study.parsing import InputSystem, parse_yaml_components
+from gems.study.parsing import SystemSchema, parse_yaml_components
 
 
 @pytest.fixture(scope="session")
@@ -34,7 +34,7 @@ def series_dir() -> Path:
 
 
 @pytest.fixture
-def input_system(systems_dir: Path) -> InputSystem:
+def input_system(systems_dir: Path) -> SystemSchema:
     compo_file = systems_dir / "system.yml"
 
     with compo_file.open() as c:
@@ -42,7 +42,7 @@ def input_system(systems_dir: Path) -> InputSystem:
 
 
 @pytest.fixture
-def input_library(libs_dir: Path) -> InputLibrary:
+def input_library(libs_dir: Path) -> LibrarySchema:
     library = libs_dir / "lib_unittest.yml"
 
     with library.open() as lib:

--- a/tests/e2e/functional/test_libs_yaml_system_yaml.py
+++ b/tests/e2e/functional/test_libs_yaml_system_yaml.py
@@ -41,11 +41,11 @@ from typing import Callable, Tuple
 
 import pytest
 
-from gems.model.parsing import InputLibrary, parse_yaml_library
+from gems.model.parsing import LibrarySchema, parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import BlockBorderManagement, TimeBlock, build_problem
 from gems.study.data import DataBase
-from gems.study.parsing import InputSystem, parse_yaml_components
+from gems.study.parsing import SystemSchema, parse_yaml_components
 from gems.study.resolve_components import (
     build_data_base,
     consistency_check,
@@ -56,7 +56,7 @@ from gems.study.system import System
 
 
 def test_basic_balance_using_yaml(
-    input_system: InputSystem, input_library: InputLibrary
+    input_system: SystemSchema, input_library: LibrarySchema
 ) -> None:
     result_lib = resolve_library([input_library])
     system = resolve_system(input_system, result_lib)

--- a/tests/e2e/models/andromede-v1/test_andromede_v1_models.py
+++ b/tests/e2e/models/andromede-v1/test_andromede_v1_models.py
@@ -17,7 +17,7 @@ from typing import List
 import pandas as pd
 import pytest
 
-from gems.model.parsing import InputLibrary, parse_yaml_library
+from gems.model.parsing import LibrarySchema, parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import build_problem
 from gems.simulation.time_block import TimeBlock
@@ -47,7 +47,7 @@ def series_dir(data_dir: Path) -> Path:
 
 
 @pytest.fixture
-def input_libraries(data_dir: Path) -> List[InputLibrary]:
+def input_libraries(data_dir: Path) -> List[LibrarySchema]:
     libs_dir = data_dir / "libs"
     with open(libs_dir / "antares_historic.yml") as lib_file:
         lib_historic = parse_yaml_library(lib_file)
@@ -116,7 +116,7 @@ def test_model_behaviour(
     timespan: int,
     batch: int,
     relative_accuracy: float,
-    input_libraries: List[InputLibrary],
+    input_libraries: List[LibrarySchema],
     results_dir: Path,
     systems_dir: Path,
     series_dir: Path,

--- a/tests/e2e/models/operators/test_operators_v1.py
+++ b/tests/e2e/models/operators/test_operators_v1.py
@@ -17,7 +17,7 @@ from typing import List
 import pandas as pd
 import pytest
 
-from gems.model.parsing import InputLibrary, parse_yaml_library
+from gems.model.parsing import LibrarySchema, parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.simulation import build_problem
 from gems.simulation.simulation_table import SimulationTableBuilder
@@ -68,7 +68,7 @@ def relative_accuracy() -> float:
 
 
 @pytest.fixture
-def input_libraries(input_dir: Path) -> List[InputLibrary]:
+def input_libraries(input_dir: Path) -> List[LibrarySchema]:
     libs_dir = input_dir / "model-libraries"
     with open(libs_dir / "test_lib.yml") as lib_file:
         lib_new = parse_yaml_library(lib_file)
@@ -90,7 +90,7 @@ def test_model_behaviour(
     optim_result_file: str,
     batch: int,
     relative_accuracy: float,
-    input_libraries: List[InputLibrary],
+    input_libraries: List[LibrarySchema],
     results_dir: Path,
     series_dir: Path,
 ) -> None:

--- a/tests/unittests/system_parsing/test_components_parsing.py
+++ b/tests/unittests/system_parsing/test_components_parsing.py
@@ -3,22 +3,22 @@ from pathlib import Path
 import pytest
 from yaml import dump, safe_load
 
-from gems.model.parsing import InputLibrary, parse_yaml_library
+from gems.model.parsing import LibrarySchema, parse_yaml_library
 from gems.model.resolve_library import resolve_library
-from gems.study.parsing import InputSystem, load_input_system, parse_yaml_components
+from gems.study.parsing import SystemSchema, load_input_system, parse_yaml_components
 from gems.study.resolve_components import consistency_check, resolve_system
 
 COMPO_FILE = Path(__file__).parent / "systems/system.yml"
 
 
 @pytest.fixture
-def input_system() -> InputSystem:
+def input_system() -> SystemSchema:
     with COMPO_FILE.open() as c:
         return parse_yaml_components(c)
 
 
 @pytest.fixture
-def input_library() -> InputLibrary:
+def input_library() -> LibrarySchema:
     library = Path(__file__).parent / "libs/lib_unittest.yml"
 
     with library.open() as lib:
@@ -26,7 +26,7 @@ def input_library() -> InputLibrary:
 
 
 def test_parsing_components_ok(
-    input_system: InputSystem, input_library: InputLibrary
+    input_system: SystemSchema, input_library: LibrarySchema
 ) -> None:
     assert len(input_system.components) == 3
     assert input_system.connections is not None
@@ -39,7 +39,7 @@ def test_parsing_components_ok(
 
 
 def test_consistency_check_ok(
-    input_system: InputSystem, input_library: InputLibrary
+    input_system: SystemSchema, input_library: LibrarySchema
 ) -> None:
     result_lib = resolve_library([input_library])
     result_system = resolve_system(input_system, result_lib)
@@ -54,7 +54,7 @@ def test_load_input_system_ok(tmp_path: Path) -> None:
 
     result = load_input_system(file_for_load)
 
-    assert isinstance(result, InputSystem)
+    assert isinstance(result, SystemSchema)
     assert len(result.components) == 3
     assert result.components[0].id == "N"
     assert result.components[1].id == "G"
@@ -82,7 +82,7 @@ def test_load_input_system_missing_file_raises_error() -> None:
 
 
 def test_consistency_check_ko(
-    input_system: InputSystem, input_library: InputLibrary
+    input_system: SystemSchema, input_library: LibrarySchema
 ) -> None:
     result_lib = resolve_library([input_library])
     result_comp = resolve_system(input_system, result_lib)


### PR DESCRIPTION
Adopts the [X]Schema naming convention (e.g. ParameterSchema, ComponentSchema) in place of the former Input[X] pattern across all source and test files. The Schema suffix is standard in Pydantic/FastAPI projects and immediately signals that these classes are validation schemas for external YAML input, distinct from the domain objects they produce.

The choice of Schema makes sense with respect to the name GEMS.

Closes #75 

https://claude.ai/code/session_01N7Zs1WhkuRpZuR3snk594N