### PR TITLE
Add LinopyModel alias to distinguish from gems.model.Model

### DIFF
--- a/src/gems/simulation/__init__.py
+++ b/src/gems/simulation/__init__.py
@@ -15,6 +15,7 @@ from .optimization import (
     BlockBorderManagement,
     DecomposedProblems,
     DecompositionFilter,
+    LinopyModel,
     OptimizationProblem,
     build_decomposed_problems,
     build_problem,

--- a/src/gems/simulation/optimization.py
+++ b/src/gems/simulation/optimization.py
@@ -56,6 +56,12 @@ from gems.study.system import Component, System
 if TYPE_CHECKING:
     from gems.optim_config.parsing import ElementLocation, OptimConfig
 
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+LinopyModel = linopy.Model
+"""Alias for :class:`linopy.Model`, distinguishing it from :class:`gems.model.Model`."""
 
 # ---------------------------------------------------------------------------
 # Decomposition filter
@@ -263,7 +269,7 @@ class OptimizationProblem:
     def __init__(
         self,
         name: str,
-        linopy_model: linopy.Model,
+        linopy_model: LinopyModel,
         study: Study,
         block: TimeBlock,
         scenarios: int,


### PR DESCRIPTION
Closes #107. Introduces `LinopyModel = linopy.Model` in `gems.simulation.optimization` and re-exports it from `gems.simulation`, so callers can reference the solver-level model without importing linopy directly and without confusing it with the GEMS component model.

https://claude.ai/code/session_01EB5vY5goa2w4hnrUREVucx