### PR TITLE
refactor: move run_study to runner.py to eliminate circular dependency

### DIFF
--- a/src/gems/main/main.py
+++ b/src/gems/main/main.py
@@ -20,7 +20,7 @@ from gems.optim_config.parsing import OptimConfig
 from gems.simulation import DecomposedProblems, build_couplings, dump_couplings
 from gems.study import Study
 from gems.study.data import DataBase
-from gems.study.folder import run_study
+from gems.study.runner import run_study
 from gems.study.parsing import parse_cli, parse_yaml_components
 from gems.study.resolve_components import build_data_base, resolve_system
 from gems.study.system import System

--- a/src/gems/session/session.py
+++ b/src/gems/session/session.py
@@ -25,6 +25,7 @@ from gems.simulation.simulation_table import (
     merge_simulation_tables,
 )
 from gems.simulation.time_block import TimeBlock
+from gems.study.folder import load_study
 from gems.study.study import Study
 
 
@@ -227,10 +228,6 @@ def load_session(
     output_dir: Optional[Path] = None,
 ) -> SimulationSession:
     """Factory: load a study from disk and build a SimulationSession."""
-    from gems.study.folder import (  # local import to avoid circular dependency
-        load_study,
-    )
-
     study = load_study(study_dir)
     config_path = study_dir / "input" / "optim-config.yml"
     optim_config = load_optim_config(config_path) or OptimConfig()

--- a/src/gems/study/folder.py
+++ b/src/gems/study/folder.py
@@ -1,5 +1,5 @@
 """
-This module provides functions to load and run simulation studies.
+This module provides functions to load simulation studies from disk.
 
 A study is defined by a directory containing:
 - `input/system.yml`: A file describing the system to be simulated.
@@ -10,17 +10,10 @@ A study is defined by a directory containing:
 """
 
 from pathlib import Path
-from typing import Optional
 
 from gems.model.model import Model
 from gems.model.parsing import parse_yaml_library
 from gems.model.resolve_library import resolve_library
-from gems.optim_config.parsing import (
-    OptimConfig,
-    load_optim_config,
-    validate_optim_config,
-)
-from gems.session.session import SimulationSession
 from gems.study.parsing import parse_yaml_components
 from gems.study.resolve_components import (
     build_data_base,
@@ -71,35 +64,3 @@ def load_study(study_dir: Path) -> Study:
         else ScenarioBuilder()
     )
     return Study(system=system, database=database, scenario_builder=scenario_builder)
-
-
-def run_study(
-    study_dir: Path,
-    optim_config_path: Optional[Path] = None,
-) -> None:
-    """
-    Runs a simulation study and exports results to CSV.
-
-    Run parameters (time scope, solver options, scenario scope) are read from
-    ``study_dir/input/optim-config.yml``; defaults apply when the file is absent.
-    Results are written to ``study_dir/output/``.
-
-    Args:
-        study_dir: The path to the study directory.
-        optim_config_path: Optional custom path to an optim-config YAML file.
-            If not provided, defaults to ``study_dir/input/optim-config.yml``.
-    """
-    study = load_study(study_dir)
-
-    resolved_config_path = optim_config_path or (
-        study_dir / "input" / "optim-config.yml"
-    )
-    optim_config = load_optim_config(resolved_config_path) or OptimConfig()
-    validate_optim_config(optim_config, study.system)
-
-    session = SimulationSession(
-        study=study,
-        optim_config=optim_config,
-    )
-    table = session.run()
-    table.to_csv(study_dir / "output")

--- a/src/gems/study/runner.py
+++ b/src/gems/study/runner.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import Optional
 
-from gems.optim_config.parsing import OptimConfig, load_optim_config, validate_optim_config
+from gems.optim_config.parsing import (
+    OptimConfig,
+    load_optim_config,
+    validate_optim_config,
+)
 from gems.session.session import SimulationSession
 from gems.study.folder import load_study
 

--- a/src/gems/study/runner.py
+++ b/src/gems/study/runner.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from typing import Optional
+
+from gems.optim_config.parsing import OptimConfig, load_optim_config, validate_optim_config
+from gems.session.session import SimulationSession
+from gems.study.folder import load_study
+
+
+def run_study(
+    study_dir: Path,
+    optim_config_path: Optional[Path] = None,
+) -> None:
+    """
+    Runs a simulation study and exports results to CSV.
+
+    Run parameters (time scope, solver options, scenario scope) are read from
+    ``study_dir/input/optim-config.yml``; defaults apply when the file is absent.
+    Results are written to ``study_dir/output/``.
+
+    Args:
+        study_dir: The path to the study directory.
+        optim_config_path: Optional custom path to an optim-config YAML file.
+            If not provided, defaults to ``study_dir/input/optim-config.yml``.
+    """
+    study = load_study(study_dir)
+
+    resolved_config_path = optim_config_path or (
+        study_dir / "input" / "optim-config.yml"
+    )
+    optim_config = load_optim_config(resolved_config_path) or OptimConfig()
+    validate_optim_config(optim_config, study.system)
+
+    session = SimulationSession(
+        study=study,
+        optim_config=optim_config,
+    )
+    table = session.run()
+    table.to_csv(study_dir / "output")

--- a/tests/e2e/functional/test_optim_modes.py
+++ b/tests/e2e/functional/test_optim_modes.py
@@ -28,7 +28,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from gems.study.folder import run_study
+from gems.study.runner import run_study
 
 _STUDY_SRC = Path(__file__).parent / "studies" / "dsr_3_blocks"
 

--- a/tests/e2e/functional/test_study_from_folder.py
+++ b/tests/e2e/functional/test_study_from_folder.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 import pandas as pd
 
-from gems.study.folder import load_study, run_study
+from gems.study.folder import load_study
+from gems.study.runner import run_study
 
 
 def test_load_study():


### PR DESCRIPTION
folder.py was importing SimulationSession from session.py, which in turn needed to import load_study from folder.py (worked around with a local import). Moving run_study to a new runner.py breaks the cycle: folder.py now only handles loading, session.py can import load_study at module level, and runner.py owns the orchestration between the two.

https://claude.ai/code/session_01GnAgJKNP5b8D8SzH1TXRMU