### PR TITLE
fix: update output globs to search subdirectories after per-run outpu…

### DIFF
--- a/tests/e2e/functional/test_optim_modes.py
+++ b/tests/e2e/functional/test_optim_modes.py
@@ -92,7 +92,7 @@ _KEY_COLS = [
 
 
 def _load_csv(study_dir: Path) -> pd.DataFrame:
-    output_files = list((study_dir / "output").glob("simulation_table_*.csv"))
+    output_files = list((study_dir / "output").glob("**/simulation_table_*.csv"))
     assert len(output_files) == 1, f"Expected 1 output file, got {len(output_files)}"
     return pd.read_csv(output_files[0])
 

--- a/tests/e2e/functional/test_study_from_folder.py
+++ b/tests/e2e/functional/test_study_from_folder.py
@@ -23,7 +23,7 @@ def test_run_study(tmp_path: Path) -> None:
 
     run_study(study_dir)
 
-    output_files = list((study_dir / "output").glob("simulation_table_*.csv"))
+    output_files = list((study_dir / "output").glob("**/simulation_table_*.csv"))
     assert len(output_files) == 1
     df = pd.read_csv(output_files[0])
     assert "objective-value" in df["output"].values


### PR DESCRIPTION
…t_dir change

runner.py now writes to output/{run_id}/simulation_table_*.csv (introduced in #124), but the e2e tests were still globbing the flat output/ directory. Switch to a recursive glob (**/) so tests find the file regardless of depth.

https://claude.ai/code/session_01PXs3nz8srGDfQPGHG8xp5m