### PR TITLE
Fix test_optim_modes CI failure: remove spurious scenario-group decla…

### DIFF
--- a/tests/e2e/functional/studies/dsr_3_blocks/input/system.yml
+++ b/tests/e2e/functional/studies/dsr_3_blocks/input/system.yml
@@ -27,7 +27,6 @@ system:
   components:
     - id: base_zone
       model: test-lib.area
-      scenario-group: sg
       parameters:
         - id: spillage_cost
           time-dependent: false
@@ -40,7 +39,6 @@ system:
 
     - id: load_base_zone
       model: test-lib.load
-      scenario-group: sg
       parameters:
         - id: load
           time-dependent: true
@@ -49,7 +47,6 @@ system:
 
     - id: wind_base_zone
       model: test-lib.renewable
-      scenario-group: sg
       parameters:
         - id: nominal_capacity
           time-dependent: false
@@ -66,7 +63,6 @@ system:
 
     - id: dsr_base_zone
       model: test-lib.dsr
-      scenario-group: sg
       parameters:
         - id: max_load
           time-dependent: false
@@ -79,7 +75,6 @@ system:
 
     - id: gas_base_zone
       model: test-lib.simple_generator
-      scenario-group: sg
       parameters:
         - id: p_min
           time-dependent: false
@@ -100,7 +95,6 @@ system:
 
     - id: oil_base_zone
       model: test-lib.simple_generator
-      scenario-group: sg
       parameters:
         - id: p_min
           time-dependent: false
@@ -121,7 +115,6 @@ system:
 
     - id: coal_base_zone
       model: test-lib.simple_generator
-      scenario-group: sg
       parameters:
         - id: p_min
           time-dependent: false


### PR DESCRIPTION
…rations

The dsr_3_blocks study declared scenario-group: sg on all 7 components but had no scenariobuilder.dat file to define that group. This was silently ignored by the old identity-fallback behaviour, but now raises a ValueError after 70c526e enforced strict validation. Since scenario mapping is irrelevant to these optimisation-mode tests (single scenario, single-column data series), simply drop the declarations.

https://claude.ai/code/session_01EDyJsnw5zAQGkWAVAruCjc