### PR TITLE
fix: resolve mypy type errors in TimeSeriesData.get_value

### DIFF
--- a/src/gems/study/data.py
+++ b/src/gems/study/data.py
@@ -83,9 +83,7 @@ class TimeSeriesData(AbstractDataStructure):
     ) -> np.ndarray:
         if timestep is None:
             raise KeyError("Time series data requires a time index.")
-        result = self.time_series.values[
-            np.asarray(timestep)
-        ]  # (T,) — skips pandas Series intermediary
+        result: np.ndarray = np.asarray(self.time_series.values)[np.asarray(timestep)]
         if scenario is not None:
             return np.broadcast_to(
                 result[:, np.newaxis], (len(timestep), len(scenario))


### PR DESCRIPTION
Wrap `time_series.values` in `np.asarray()` so `result` is always `np.ndarray`, eliminating the invalid ExtensionArray tuple-index and incompatible return-value errors.

https://claude.ai/code/session_016diUF6LYFhJdn2JrJyj9Di